### PR TITLE
fix(exporters): correct pdf export package name to net-benchmark[pdf]

### DIFF
--- a/src/net_benchmark/dns_benchmark/exporters.py
+++ b/src/net_benchmark/dns_benchmark/exporters.py
@@ -583,7 +583,7 @@ class PDFExporter:
     ) -> None:
         if HTML is None:
             raise RuntimeError(
-                "PDF export requires 'weasyprint'. Install with: pip install dns-benchmark-tool[pdf]"
+                "PDF export requires 'weasyprint'. Install with: pip install net-benchmark[pdf]"
             )
 
         charts_dir = tempfile.mkdtemp()


### PR DESCRIPTION
update the weasyprint installation hint from
dns-benchmark-tool[pdf] to net-benchmark[pdf]