### PR TITLE
feat(http): release 0.5.0 — http benchmarking suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,10 @@ Thumbs.db
 # Project Specific
 # -----------------
 benchmark_results/
+monitoring_results/
 release.sh
 release-tag.sh
 gpg-check.sh
 {outdir}
 notes/
-# src/net_benchmark/http_bench/
 src/net_benchmark/ssl_check/

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,5 @@ release-tag.sh
 gpg-check.sh
 {outdir}
 notes/
-src/net_benchmark/http_bench/
+# src/net_benchmark/http_bench/
 src/net_benchmark/ssl_check/

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -4,7 +4,8 @@ fast, extensible network benchmarking — dns, http, and ssl from a single cli.
 
 [![PyPI version](https://badge.fury.io/py/net-benchmark.svg)](https://pypi.org/project/net-benchmark)
 [![Python](https://img.shields.io/pypi/pyversions/net-benchmark.svg)](https://pypi.org/project/net-benchmark)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![License](https://img.shields.io/badge/license-MIT-yellow.svg)
+
 [![CI](https://github.com/net-benchmark/net-benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/net-benchmark/net-benchmark/actions)
 [![Downloads](https://pepy.tech/badge/net-benchmark)](https://pepy.tech/project/net-benchmark)
 
@@ -48,11 +49,33 @@ full documentation: [github.com/net-benchmark/net-benchmark](https://github.com/
 </details>
 
 <details>
-<summary><strong>http benchmark</strong> — endpoint latency and availability <em>(coming 0.5.0)</em></summary>
+<summary><strong>http benchmark</strong> — latency, ttfb, security headers, tls certs</summary>
 
 ```bash
-net-benchmark http benchmark --targets "https://api.example.com"
+net-benchmark http benchmark --use-defaults
+net-benchmark http benchmark --use-defaults --iterations 5
+net-benchmark http benchmark --targets "https://api.example.com" --method POST --body '{}'
+net-benchmark http compare api.example.com api2.example.com --iterations 3
+net-benchmark http top --use-defaults --limit 5
+net-benchmark http monitoring --use-defaults --interval 30
 ```
+
+| flag | description | default |
+|---|---|---|
+| `--use-defaults` | built-in target urls | — |
+| `--targets` | comma-separated urls or file | — |
+| `--method` | http verb (get, post, etc.) | `get` |
+| `--headers` | `"key:value,key2:value2"` | — |
+| `--body` | inline request body (e.g. json) | — |
+| `--body-file` | path to body file | — |
+| `--auth` | `basic:user:pass` or `bearer:token` | — |
+| `--cert` / `--cert-key` | mtls client certificate | — |
+| `--proxy` | proxy url | — |
+| `--assert` | repeatable: `status=200`, `body_contains=ok`, `max_latency=500`, etc. | — |
+| `--iterations` | requests per target | `1` |
+| `--no-http2` | force http/1.1 | `false` |
+| `--no-verify-ssl` | skip tls verification | `false` |
+| `--formats` | csv, excel, pdf, json | `csv,excel,pdf` |
 
 full documentation: [github.com/net-benchmark/net-benchmark](https://github.com/net-benchmark/net-benchmark#http-benchmark)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ pip install -e .
 ```bash
 net-benchmark --version
 net-benchmark dns --help
+net-benchmark http --help
+
+# See all available options for a specific command
+net-benchmark dns benchmark --help
+net-benchmark http benchmark --help
 ```
 
 ### First Run
@@ -65,6 +70,9 @@ net-benchmark dns --help
 ```bash
 # Test with defaults (recommended for first time)
 net-benchmark dns benchmark --use-defaults --formats csv,excel
+
+# HTTP test with defaults
+net-benchmark http benchmark --use-defaults --formats csv,excel
 ```
 
 ---
@@ -1238,16 +1246,529 @@ Run multiple iterations (`--iterations 5`) for more consistent results.
 
 ### HTTP benchmark
 
-<details>
-<summary><strong>HTTP benchmark</strong> — benchmark http/https endpoints <em>(coming in 0.5.0)</em></summary>
+<details open>
+<summary><strong>HTTP benchmark</strong> — latency, TTFB, security headers, CDN fingerprinting, TLS certs</summary>
 
-#### Planned features
+#### 🎯 Why This Tool?
 
-- measure TTFB, download speed, redirect chains
-- support for HTTP/2 and HTTP/3
-- configurable headers and authentication
+Every HTTP request hides a dozen performance and security signals — DNS, TCP, TLS, redirects, compression, caching, CDN routing, and server software.  
+Most tools measure only total latency. net‑benchmark gives you the full picture.
 
-> **Status:** planned for version 0.5.0 — [contributions welcome](CONTRIBUTING.md)
+##### The Problem
+
+- ⏱️ **Hidden bottlenecks** — is the delay DNS, TCP, TLS, or the server itself?
+- 🔗 **Silent redirects** — each hop adds latency you can't see without per‑hop timing
+- 🔒 **Missing security headers** — CSP, HSTS, X‑Frame‑Options often absent
+- 🕵️ **Unknown CDN** — what CDN is actually serving your traffic?
+- 📜 **Expired certificates** — hard to catch before they break production
+
+##### The Solution
+
+net‑benchmark helps you:
+
+- 🔍 **Break down every request** — DNS → TCP → TLS → TTFB → TTLB, all in milliseconds
+- 📊 **Get real stats** — P95, P99, jitter, consistency scores
+- 🛡️ **Audit security** — HSTS, CSP, X‑Frame‑Options, CDN fingerprinting, server header leaks
+- 📜 **Capture TLS certs** — expiry days, CN, issuer, SANs, wildcard detection
+- 🚀 **Test at scale** — 50+ concurrent requests in seconds
+
+##### Perfect For
+
+- ✅ **Developers** optimising API performance
+- ✅ **DevOps/SRE** validating CDN and origin server SLAs
+- ✅ **Security engineers** auditing HTTP security headers and TLS hygiene
+- ✅ **API providers** benchmarking endpoints with auth, headers, and body payloads
+
+---
+
+#### Quick start
+
+```bash
+# Test 5 built‑in targets with a single iteration
+net-benchmark http benchmark --use-defaults
+```
+
+Results are automatically saved to `./benchmark_results/` with summary CSV, detailed raw data, and optional PDF/Excel reports.
+
+```bash
+# First‑run recommendations
+net-benchmark http benchmark --use-defaults --formats csv,excel
+net-benchmark http benchmark --use-defaults --iterations 5   # meaningful jitter/consistency
+```
+
+---
+
+#### ⚡ Commands at a Glance
+
+| Command | What it does | Quick example |
+|---|---|---|
+| `benchmark` | Full HTTP benchmark with exports | `net-benchmark http benchmark --use-defaults` |
+| `top` | Rank all targets by speed | `net-benchmark http top --limit 5` |
+| `compare` | Side‑by‑side target comparison | `net-benchmark http compare api.example.com api2.example.com` |
+| `monitoring` | Continuous monitoring with alerts | `net-benchmark http monitoring --use-defaults` |
+
+```bash
+# Find your fastest endpoint right now
+net-benchmark http top --limit 5
+
+# Compare two APIs side‑by‑side
+net-benchmark http compare api.example.com api2.example.com --iterations 3 --show-details
+
+# Monitor with alerts for 1 hour
+net-benchmark http monitoring --use-defaults \
+  --interval 30 --duration 3600 \
+  --alert-latency 500 --alert-failure-rate 5
+```
+
+---
+
+#### ✨ Key Features
+
+##### 🚀 Performance
+
+- **Async engine** — httpx with HTTP/2, connection pooling, semaphore concurrency
+- **Timing breakdown** — DNS resolve, TCP connect, TLS handshake, TTFB, TTLB, total latency
+- **Multi‑iteration** — run benchmarks multiple times for statistical accuracy
+- **Statistical analysis** — mean, median, P95, P99, jitter, consistency score
+- **Retry with backoff** — exponential backoff on failures (mirrors DNS engine)
+- **Configurable concurrency** — control max concurrent requests
+- **Warmup phase** — optional HEAD or full warmup before measurement
+
+##### 🔒 Security & TLS
+
+- **Security headers audit** — HSTS, CSP, X‑Frame‑Options, X‑Content‑Type‑Options, Referrer‑Policy, Permissions‑Policy
+- **CDN fingerprinting** — detects Cloudflare, CloudFront, Fastly, Akamai, Google, Azure CDN
+- **Server header leak detection** — flags software/version disclosure
+- **Inline TLS cert capture** — expiry days, CN, issuer, SANs, wildcard detection
+- **Downgrade detection** — HTTPS→HTTP redirect chains and HTTP/2→HTTP/1.1 fallback
+- **IPv4 vs IPv6** — dual‑stack detection per request
+- **Alt‑Svc detection** — server advertising HTTP/3
+
+##### 🔐 Auth & Enterprise
+
+- **Basic auth, Bearer token, custom API key** — `--auth basic:user:pass`, `--auth bearer:token`, `--headers x-api-key:key`
+- **mTLS client certificates** — `--cert` + `--cert-key`
+- **Proxy support** — `--proxy http://proxy:8080`
+- **SNI override** — `--sni example.com`
+- **Interface binding** — `--local-address 192.168.1.100`
+- **Request ID injection** — `--inject-request-id` adds X‑Request‑ID header
+- **Custom User‑Agent** — `--user-agent "MyBot/1.0"`
+- **Cookies** — repeatable `--cookie "name=value"` flag
+
+##### 🧪 Assertions & Validation
+
+- **Assert status code** — `--assert status=200`
+- **Assert body contains** — `--assert body_contains=success`
+- **Assert header exists** — `--assert header_exists=X-Cache`
+- **Assert header value** — `--assert header_value=X-Cache=HIT`
+- **Assert max latency** — `--assert max_latency=500`
+- **Assert content‑type** — `--assert content_type=application/json`
+- **Assert response size** — `--assert response_size_min=100`, `--assert response_size_max=10000`
+
+##### 📊 Analysis & Export
+
+- **Multiple formats** — CSV, Excel, PDF, JSON (see [Export formats](#export-formats))
+- **Visual reports** — charts and graphs in Excel/PDF
+- **Per‑target statistics** — latency, TTFB, HTTP/2 rate, redirect rate, compressed size
+- **Cache header analysis** — Cache‑Control, ETag, Last‑Modified, Age presence
+- **Status code distribution** — 2xx/3xx/4xx/5xx breakdown
+- **Error breakdown** — identify problematic targets
+
+---
+
+#### 🔧 HTTP/2, Redirects, and Downgrade Detection
+
+| Feature | What it captures |
+|---|---|
+| HTTP/2 negotiation | ALPN result (`h2` or `http/1.1`) per request |
+| HTTP/2 downgrade detection | Flags when HTTP/2 was expected but HTTP/1.1 was negotiated |
+| Redirect chain | Full hop list with per‑hop URL, status code, and duration |
+| Downgrade detection | Flags any HTTPS→HTTP redirect in the chain |
+| Compressed size | Content‑Length header captured for bandwidth analysis |
+
+```bash
+# Force HTTP/1.1 to compare performance
+net-benchmark http benchmark --use-defaults --no-http2
+
+# Watch redirect chains
+net-benchmark http benchmark --targets https://github.com --iterations 1
+
+# Detect HTTP/2 downgrades (useful behind corporate proxies)
+net-benchmark http benchmark --use-defaults --iterations 3
+```
+
+---
+
+#### 🔒 Security & Auth Examples
+
+```bash
+# Basic auth
+net-benchmark http benchmark \
+  --targets https://httpbin.org/basic-auth/user/pass \
+  --auth "basic:user:pass"
+
+# Bearer token (standard OAuth2)
+net-benchmark http benchmark \
+  --targets https://api.example.com/data \
+  --auth "bearer:sk-abc123"
+
+# Custom API key header (x‑api‑key)
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --headers "x-api-key:sk-abc123"
+
+# mTLS client certificate
+net-benchmark http benchmark \
+  --targets https://mtls.example.com \
+  --cert client.pem --cert-key client-key.pem
+
+# Proxy with auth
+net-benchmark http benchmark \
+  --targets https://example.com \
+  --proxy http://proxy:8080 \
+  --auth "basic:proxyuser:proxypass"
+```
+
+---
+
+#### 💼 Use Cases
+
+##### 🔧 For Developers: Optimise API Performance
+
+```bash
+# Find fastest endpoint and break down timing
+net-benchmark http benchmark \
+  --targets https://api.myapp.com/v1/users,https://api.myapp.com/v2/users \
+  --method GET \
+  --headers "Authorization:Bearer token" \
+  --iterations 5
+```
+
+**Result:** Pinpoint whether DNS, TCP, TLS, or server logic is the bottleneck.
+
+---
+
+##### 🛡️ For DevOps/SRE: Validate CDN Migration
+
+```bash
+# Compare old origin vs new CDN
+net-benchmark http compare \
+  https://origin.example.com \
+  https://cdn.example.com \
+  --iterations 5 --show-details
+```
+
+**Result:** Data‑driven proof your CDN is (or isn't) faster.
+
+---
+
+##### 🔐 For Security Engineers: Audit Public Endpoints
+
+```bash
+# Full security audit with assertions
+net-benchmark http benchmark \
+  --targets https://www.example.com,https://api.example.com \
+  --assert status=200 \
+  --assert header_exists=strict-transport-security \
+  --assert header_value=X-Content-Type-Options=nosniff \
+  --formats excel,pdf \
+  --output ./security_audit
+```
+
+**Result:** Instant report card of security header coverage and TLS certificate health.
+
+---
+
+##### 🏢 For Enterprise: Automated Health Checks
+
+```bash
+# Add to crontab for hourly reports
+0 * * * * net-benchmark http benchmark \
+  --targets targets.txt \
+  --assert status=200 --assert max_latency=1000 \
+  --formats csv --quiet \
+  --output /var/reports/http/$(date +\%Y\%m\%d_\%H)
+```
+
+**Result:** Automated SLA compliance and performance trending.
+
+---
+
+#### 📖 Usage Examples
+
+##### Basic Usage
+
+```bash
+# Test built‑in defaults
+net-benchmark http benchmark --use-defaults
+
+# Custom targets from file
+net-benchmark http benchmark --targets ./targets.txt
+
+# Inline targets (comma‑separated)
+net-benchmark http benchmark --targets "https://example.com,https://httpbin.org/get"
+
+# Quick test with only CSV output
+net-benchmark http benchmark --use-defaults --formats csv --quiet
+
+# Multiple iterations for statistical accuracy
+net-benchmark http benchmark --use-defaults --iterations 5
+
+# Custom HTTP method with body
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --body '{"action":"test"}'
+
+# Body from file
+echo '{"name":"test","value":42}' > payload.json
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --body-file payload.json
+```
+
+##### Advanced Usage
+
+```bash
+# Export all formats with charts
+net-benchmark http benchmark \
+  --use-defaults \
+  --formats csv,excel,pdf \
+  --include-charts \
+  --json \
+  --output ./full_report
+
+# Separate timeout control
+net-benchmark http benchmark \
+  --targets https://slow-api.example.com \
+  --connect-timeout 5 --read-timeout 30 --write-timeout 10
+
+# Query parameters without hacking the URL
+net-benchmark http benchmark \
+  --targets https://api.example.com/search \
+  --params "page=1,limit=50,q=test"
+
+# High concurrency with warmup
+net-benchmark http benchmark \
+  --use-defaults \
+  --max-concurrent 100 \
+  --warmup-fast \
+  --iterations 3
+
+# Full assertion suite
+net-benchmark http benchmark \
+  --targets https://api.example.com/health \
+  --assert status=200 \
+  --assert body_contains=ok \
+  --assert max_latency=500 \
+  --assert content_type=application/json \
+  --assert response_size_min=10
+```
+
+##### CI/CD Integration
+
+```yaml
+- name: HTTP Endpoint Health Check
+  run: |
+    pip install net-benchmark
+    net-benchmark http benchmark \
+      --targets "https://api.prod.example.com/health,https://web.prod.example.com" \
+      --assert status=200 \
+      --assert max_latency=1000 \
+      --formats csv \
+      --quiet
+```
+
+---
+
+#### ⚡ CLI Commands
+
+##### 🚀 Top
+
+Quickly rank targets by speed or reliability.
+
+```bash
+# Rank default targets by latency
+net-benchmark http top --use-defaults --limit 5
+
+# Rank by TTFB
+net-benchmark http top --use-defaults --limit 5 --metric ttfb
+
+# Rank by success rate
+net-benchmark http top --targets targets.txt --limit 10 --metric success
+```
+
+---
+
+##### 📊 Compare
+
+Benchmark specific targets side‑by‑side with detailed statistics.
+
+```bash
+# Compare two targets
+net-benchmark http compare https://example.com https://httpbin.org/get
+
+# Auto‑scheme (https:// added if missing)
+net-benchmark http compare api.example.com api2.example.com
+
+# With auth and iterations
+net-benchmark http compare api.example.com api2.example.com \
+  --auth "bearer:token" --iterations 5
+
+# Show per‑iteration breakdown
+net-benchmark http compare api.example.com api2.example.com \
+  --iterations 3 --show-details
+
+# Export comparison
+net-benchmark http compare api.example.com api2.example.com \
+  --output comparison.csv
+```
+
+---
+
+##### 🔄 Monitoring
+
+Continuously monitor targets with configurable alerts.
+
+```bash
+# Monitor defaults every 60 seconds
+net-benchmark http monitoring --use-defaults
+
+# Monitor with custom targets and alerts
+net-benchmark http monitoring \
+  --targets targets.txt \
+  --interval 30 \
+  --duration 3600 \
+  --alert-latency 500 \
+  --alert-failure-rate 5 \
+  --output ./monitoring_logs
+
+# Monitor behind a proxy
+net-benchmark http monitoring \
+  --targets https://internal-api.example.com \
+  --proxy http://proxy:8080 \
+  --interval 60
+```
+
+---
+
+##### 🌟 Command Showcase
+
+| Command | Purpose | Typical Use Case | Key Options | Output |
+|---|---|---|---|---|
+| **top** | Quick ranking of targets by speed/reliability | Fast check to see which endpoint is best right now | `--limit`, `--metric`, `--iterations` | Sorted list with latency & success rate |
+| **compare** | Side‑by‑side comparison of specific targets | Detailed benchmarking across chosen endpoints | `--iterations`, `--show-details`, `--output` | Table with latency, TTFB, success rate, per‑iteration breakdown |
+| **monitoring** | Continuous monitoring with alerts | Real‑time tracking of endpoint health over time | `--interval`, `--duration`, `--alert-latency`, `--alert-failure-rate`, `--output` | Live status, alerts, per‑interval JSON snapshots |
+
+---
+
+#### ⚡ Best Practices
+
+| Mode | Recommended Flags | Purpose |
+|---|---|---|
+| **Quick Run** | `--iterations 1 --warmup-fast` | Fast feedback, lightweight warmup |
+| **Thorough Run** | `--iterations 5 --warmup --timeout 10 --retries 2` | Multiple passes, full warmup, best for detailed benchmarking |
+| **Debug Mode** | `--iterations 1 --timeout 30 --retries 0` | Long timeout, no retries, useful for diagnosing endpoint issues |
+| **API Testing** | `--method POST --body '{}' --headers "Auth:token" --assert status=200` | Send payloads and validate responses |
+
+---
+
+#### 📊 What the Summary Shows
+
+```text
+============================================
+| Total requests:   5                      |
+| Successful:       4 (80.00%)             |
+| Avg latency:      1047.25 ms             |
+| Avg TTFB:         772.20 ms              |
+| HTTP/2 rate:      100.0%                 |
+| HSTS coverage:    60.0%                  |
+| Assertion pass:   100.0%                 |
+| Fastest target:   https://www.apple.com  |
+| Slowest target:   https://www.github.com |
+============================================
+```
+
+---
+
+#### 🔧 Troubleshooting
+
+```bash
+# Command not found
+pip install -e .
+python -m net_benchmark.http_bench.cli --help
+
+# PDF generation fails (Ubuntu/Debian) – see PDF dependencies
+sudo apt-get install libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+  libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+# Or skip PDF
+net-benchmark http benchmark --use-defaults --formats csv,excel
+
+# Network timeouts
+net-benchmark http benchmark --use-defaults --timeout 30 --retries 3
+net-benchmark http benchmark --use-defaults --max-concurrent 10
+
+# SSL errors on internal servers
+net-benchmark http benchmark --targets https://internal.local --no-verify-ssl
+```
+
+---
+
+#### Getting help
+
+```bash
+net-benchmark http --help
+net-benchmark http benchmark --help
+net-benchmark http top --help
+net-benchmark http compare --help
+net-benchmark http monitoring --help
+```
+
+Common scenarios:
+
+```bash
+# I'm new — where to start?
+net-benchmark http benchmark --use-defaults
+
+# Test a specific API with auth
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --headers "x-api-key:sk-abc123" \
+  --body '{"test":true}'
+
+# Generate a security audit report
+net-benchmark http benchmark \
+  --targets https://www.example.com \
+  --assert status=200 \
+  --assert header_exists=strict-transport-security \
+  --formats excel,pdf \
+  --output ./security_audit
+```
+
+---
+
+#### ❓ FAQ
+
+**Why is my API slower than expected?**
+The timing breakdown (DNS → TCP → TLS → TTFB → TTLB) tells you exactly where the time goes. If DNS is slow, check your resolver. If TLS is slow, check certificate chain size or OCSP stapling. If TTFB is slow, the server logic or database is the bottleneck.
+
+**How often should I benchmark HTTP endpoints?**
+- **One‑time**: When choosing a CDN or API provider
+- **Daily**: For critical production endpoints
+- **Before deployment**: To catch performance regressions
+- **After incidents**: To validate fixes
+
+**Can I test endpoints behind authentication?**
+Yes — `--auth basic:user:pass`, `--auth bearer:token`, or `--headers x-api-key:key` all work. mTLS is also supported via `--cert` and `--cert-key`.
+
+**Is this tool safe to use in production?**
+Yes! It only performs standard HTTP requests (read operations). It does not modify data, perform attacks, or send data to external servers.
+
+**Why do results vary between runs?**
+HTTP performance varies due to network conditions, server load, CDN routing changes, and TLS session resumption. Run multiple iterations (`--iterations 5`) for more consistent results. Use `--warmup-fast` to absorb cold‑start effects.
 
 </details>
 
@@ -1307,6 +1828,24 @@ Run multiple iterations (`--iterations 5`) for more consistent results.
 
 By default, the tool supports **CSV** and **Excel** exports.  
 PDF export requires the extra dependency **weasyprint**, which is not installed automatically to avoid runtime issues on some platforms.
+
+### HTTP‑specific exports
+
+| CSV file | Contents |
+|----------|----------|
+| `*_raw.csv` | Individual request results with timing breakdown |
+| `*_summary.csv` | Per‑target aggregated statistics |
+| `*_security.csv` | Security headers presence matrix |
+| `*_ttfb.csv` | Time‑to‑first‑byte analysis |
+| `*_protocols.csv` | HTTP/1.1 vs HTTP/2 distribution |
+
+### Excel report (HTTP)
+
+- **Raw Data** sheet: all requests with timing, security headers, cert details
+- **Target Summary** sheet: comprehensive per‑target statistics
+- **TTFB Analysis** sheet: TTFB percentiles per target
+- **Security Headers** sheet: colour‑coded presence matrix
+- **Charts** sheet: latency comparison, TTFB comparison, success rates (optional)
 
 #### Install with PDF support
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,2018 @@
+# net-benchmark
+
+快速、可扩展的网络性能基准测试 — DNS、HTTP、SSL，一个命令行工具全搞定。
+
+[![PyPI version](https://badge.fury.io/py/net-benchmark.svg)](https://pypi.org/project/net-benchmark)
+[![Python](https://img.shields.io/pypi/pyversions/net-benchmark.svg)](https://pypi.org/project/net-benchmark)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CI](https://github.com/net-benchmark/net-benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/net-benchmark/net-benchmark/actions)
+[![Downloads](https://pepy.tech/badge/net-benchmark)](https://pepy.tech/project/net-benchmark)
+
+```bash
+pip install net-benchmark
+pip install net-benchmark[pdf]   # 如需导出 PDF
+```
+
+> **原项目 `dns-benchmark-tool` 的继承者** — 完全向下兼容。  
+> `dns-benchmark` 命令依然可用。
+
+---
+
+## 目录
+
+- [安装](#安装)
+- [工具](#工具)
+  - [DNS 基准测试](#dns-基准测试)
+  - [HTTP 基准测试](#http-基准测试)
+  - [SSL 检查](#ssl-检查)
+- [导出格式](#导出格式)
+- [发布流程](#发布流程)
+- [链接与支持](#链接与支持)
+- [贡献](#贡献)
+- [许可证](#许可证)
+
+---
+
+## 安装
+
+```bash
+pip install net-benchmark          # 核心功能
+pip install net-benchmark[pdf]     # 包含 PDF 导出
+```
+
+### 环境要求
+
+- Python 3.9+
+- pip 包管理器
+
+### 从源码安装
+
+```bash
+git clone https://github.com/net-benchmark/net-benchmark.git
+cd net-benchmark
+pip install -e .
+```
+
+### 验证安装
+
+```bash
+net-benchmark --version
+net-benchmark dns --help
+net-benchmark http --help
+
+# 查看某个命令的所有选项
+net-benchmark dns benchmark --help
+net-benchmark http benchmark --help
+```
+
+### 第一次运行
+
+```bash
+# 使用默认配置快速体验（推荐）
+net-benchmark dns benchmark --use-defaults --formats csv,excel
+
+# HTTP 基准测试快速体验
+net-benchmark http benchmark --use-defaults --formats csv,excel
+```
+
+---
+
+## 工具
+
+### DNS 基准测试
+
+<details>
+<summary><strong>DNS 基准测试</strong> — 测试 DNS 解析器性能、DNSSEC、DoH/DoT</summary>
+
+#### 🎯 为什么需要这个工具？
+
+DNS 解析往往是网络性能的隐形瓶颈。一个慢的解析器可能让每个请求都增加数百毫秒的延迟。
+
+##### 问题
+
+- ⏱️ **隐形瓶颈**：DNS 可能让每次请求增加 300ms 以上
+- 🤷 **性能未知**：大多数开发者从未测试过自己的 DNS
+- 🌍 **地理位置敏感**：“最快”的解析器取决于你所在的位置
+- 🔒 **安全性参差不齐**：DNSSEC、DoH、DoT 的支持程度大相径庭
+
+##### 解决方案
+
+net-benchmark 可以帮你：
+
+- 🔍 **找到最快的** DNS 解析器（针对你的网络环境）
+- 📊 **获取真实数据** — P95、P99、抖动、稳定性评分
+- 🛡️ **验证安全性** — 内置 DNSSEC 验证
+- 🚀 **大规模测试** — 数秒内完成 100+ 并发查询
+
+##### 谁适合用？
+
+- ✅ **开发者** — 优化 API 性能
+- ✅ **DevOps/SRE** — 验证解析器 SLA
+- ✅ **自建 DNS 用户** — 对比 Pi-hole/Unbound 与公共 DNS
+- ✅ **网络管理员** — 执行合规性检查
+
+---
+
+#### 快速开始
+
+```bash
+# 使用默认解析器和域名进行测试
+net-benchmark dns benchmark --use-defaults --formats csv,excel
+```
+
+结果会自动保存到 `./benchmark_results/`，包含汇总 CSV、详细原始数据，以及可选的 PDF/Excel 报告。
+
+> 安装详情见 [安装](#安装)。  
+> PDF 导出依赖见 [导出格式](#导出格式) 中的 [PDF 依赖](#pdf-dependencies)。
+
+---
+
+#### ⚡ 命令一览
+
+| 命令 | 功能 | 快速示例 |
+|---|---|---|
+| `benchmark` | 完整 DNS 基准测试并导出 | `net-benchmark dns benchmark --use-defaults` |
+| `top` | 按速度对解析器排名 | `net-benchmark dns top --limit 5` |
+| `compare` | 解析器对比 | `net-benchmark dns compare Cloudflare Google Quad9` |
+| `monitoring` | 持续监控并告警 | `net-benchmark dns monitoring --use-defaults` |
+
+```bash
+# 立刻找出你当前最快的解析器
+net-benchmark dns top --limit 5
+
+# 对比三大公共 DNS
+net-benchmark dns compare Cloudflare Google Quad9 --show-details
+
+# 使用 DoT 监控 1 小时并设置延迟告警
+net-benchmark dns monitoring --use-defaults --dot \
+  --interval 30 --duration 3600 \
+  --alert-latency 150 --output monitor.log
+```
+
+---
+
+#### ✨ 核心特性
+
+##### 🚀 性能
+
+- **异步查询** — 可同时测试 100+ 个解析器
+- **多次迭代** — 多次运行以获取更准确的结果
+- **统计分析** — 均值、中位数、P95、P99、抖动、稳定性
+- **缓存控制** — 可选择是否利用 DNS 缓存
+
+##### 🔒 安全与隐私
+
+- **DNSSEC 验证** — 验证加密信任链
+- **DNS-over-HTTPS (DoH)** — 加密 DNS 基准测试
+- **DNS-over-TLS (DoT)** — 安全传输层测试
+- **DNS-over-QUIC (DoQ)** — 实验性 QUIC 支持
+
+##### 📊 分析与导出
+
+- **多种格式** — CSV、Excel、PDF、JSON（详见 [导出格式](#导出格式)）
+- **可视化报告** — 图表和图形
+- **域名统计** — 按域名分析性能
+- **错误分类** — 识别有问题的解析器
+
+##### 🏢 企业特性
+
+- **TSIG 认证** — 企业级安全查询
+- **区域传输** — AXFR/IXFR 验证
+- **动态更新** — 测试 DNS 写操作
+- **合规报告** — 审计就绪的文档
+
+##### 🌐 跨平台
+
+- **Linux、macOS、Windows** — 全平台支持
+- **CI/CD 友好** — JSON 输出、退出码
+- **IDNA 支持** — 国际化域名
+- **自动检测** — Windows WMI DNS 发现
+
+---
+
+#### 🔒 安全与加密 DNS
+
+支持三种协议，各自有隐私增益，但会增加一定延迟。
+
+| 协议 | 参数 | 典型额外延迟 | 适用场景 |
+|---|---|---|---|
+| 普通 UDP | *(默认)* | 基准值 | 延迟基准测试 |
+| DNS-over-HTTPS | `--doh` | +50–200ms | 隐私、绕过防火墙 |
+| DNS-over-TLS | `--dot` | +200–500ms (初次), ~50ms (复用) | 加密传输 |
+| DNSSEC | `--dnssec-validate` | +30–100ms | 验证解析器完整性 |
+
+> ⚠️ **权衡说明**
+> - DoH 和 DoT 在第一次查询每个解析器时会增加 TLS 握手开销。使用 `--warmup-fast` 可在测量前消除这部分影响。
+> - `--dnssec-validate` 会请求 RRSIG 记录并强制要求 AD 标志。只有约 33% 的常用域名签名了 DNSSEC —— 未签名的域名会返回 `DNSSEC_FAILED` 结果。开启与关闭此选项的延迟数据**不能直接对比**。
+> - 手机热点或移动网络结果的方差可能是有线网络的 2–5 倍。建议使用 `--iterations 5` 并比较中位数延迟而非平均值。
+
+```bash
+# DoH 基准测试
+net-benchmark dns benchmark \
+  --resolvers "Cloudflare,Google" \
+  --domains "cloudflare.com,google.com" \
+  --doh --warmup-fast
+
+# 自定义 DoH URL（需与解析器一一对应，数量不匹配会提前报错）
+net-benchmark dns benchmark \
+  --resolvers "Cloudflare,Google" \
+  --domains "bing.com,google.com" \
+  --doh \
+  --doh-url "https://cloudflare-dns.com/dns-query,https://dns.google/dns-query" \
+  --iterations 1 \
+  --formats csv \
+  --output ./doh_results_explicit_urls
+
+# DoT + DNSSEC（仅签名域名）
+net-benchmark dns benchmark \
+  --resolvers "Cloudflare,Quad9" \
+  --domains "cloudflare.com,quad9.net" \
+  --dot \
+  --dnssec-validate
+
+# DoH 排名
+net-benchmark dns top --doh --limit 5
+
+# DoT 可靠性排名
+net-benchmark dns top --dot --metric reliability --limit 5
+
+# 对比 DoH 解析器
+net-benchmark dns compare Cloudflare Google --doh --iterations 3
+
+# DoT 监控
+net-benchmark dns monitoring --use-defaults --dot \
+  --interval 60 --alert-latency 300
+
+# DoH + DNSSEC 并导出
+net-benchmark dns benchmark --use-defaults --doh --dnssec-validate --formats csv,excel
+
+# DoT + DNSSEC + 多次迭代
+net-benchmark dns benchmark \
+  --resolvers "Cloudflare,Quad9,Google" \
+  --domains "cloudflare.com,quad9.net,google.com" \
+  --dot \
+  --dnssec-validate \
+  --iterations 5 \
+  --formats excel
+
+# DoH + 自定义 URL + 监控
+net-benchmark dns monitoring \
+  --resolvers "Cloudflare,Google" \
+  --doh \
+  --doh-url "https://cloudflare-dns.com/dns-query,https://dns.google/dns-query" \
+  --interval 30 --duration 7200
+```
+
+**提前失败的例子** — 这些命令会在运行任何查询前立即报错：
+
+```bash
+# --doh 和 --dot 互斥
+net-benchmark dns benchmark --use-defaults --doh --dot
+# ERROR: --doh and --dot are mutually exclusive.
+
+# --doh-url 数量必须与 --resolvers 数量一致
+net-benchmark dns benchmark --resolvers "Cloudflare,Google" --doh \
+  --doh-url "https://cloudflare-dns.com/dns-query"
+# ERROR: --doh-url has 1 URL(s) but --resolvers has 2 resolver(s). Counts must match.
+
+# 自定义 IP 使用 --doh 时必须提供 --doh-url
+net-benchmark dns benchmark --resolvers "192.168.1.1" --doh
+# ERROR: --doh requires a DoH URL for: 192.168.1.1. Use --doh-url to supply them explicitly.
+```
+
+---
+
+#### 🔧 高级功能
+
+> ⚠️ 以下参数已**在文档中标出**，但尚未实现。它们是未来的高级特性。
+
+- `--zone-transfer` → AXFR/IXFR 区域传输测试 *(即将推出)*
+- `--tsig` → TSIG 认证查询 *(即将推出)*
+- `--idna` → 国际化域名支持 *(即将推出)*
+
+<details>
+<summary><b>🚀 性能与并发特性</b></summary>
+
+<br>
+
+- **基于 dnspython 的异步 I/O** — 可同时测试 100+ 个解析器
+- **Trio 框架支持** — 高并发异步操作
+- **可配置并发数** — 控制最大并发查询数
+- **重试逻辑** — 失败查询的指数退避重试
+- **缓存模拟** — 可选择是否利用 DNS 缓存
+- **多次迭代基准测试** — 多次运行提高准确性
+- **预热阶段** — 在测试前预热 DNS 缓存
+- **统计分析** — 均值、中位数、P95、P99、抖动、稳定性评分
+
+**示例：**
+
+```bash
+net-benchmark dns benchmark \
+  --max-concurrent 200 \
+  --iterations 5 \
+  --timeout 3.0 \
+  --warmup
+```
+
+</details>
+
+<details>
+<summary><b>🔒 安全与隐私特性</b></summary>
+
+<br>
+
+- **DNSSEC 验证** — 验证加密信任链
+- **DNS-over-HTTPS (DoH)** — 基于 HTTPS 的加密 DNS 基准测试
+- **DNS-over-TLS (DoT)** — 安全传输层测试
+- **DNS-over-QUIC (DoQ)** — 实验性 QUIC 协议支持
+- **TSIG 认证** — 企业级 DNS 事务签名
+- **EDNS0 支持** — 扩展 DNS 功能和更大负载
+
+**示例：**
+
+```bash
+# 测试 DoH 解析器
+net-benchmark dns benchmark \
+  --doh \
+  --resolvers doh-providers.json \
+  --dnssec-validate
+```
+
+</details>
+
+<details>
+<summary><b>🏢 企业及迁移特性</b></summary>
+
+<br>
+
+- **区域传输 (AXFR/IXFR)** — 完整和增量区域传输验证
+- **动态 DNS 更新** — 测试 DNS 写操作
+- **EDNS0 支持** — 扩展 DNS 选项、客户端子网、更大负载
+- **Windows WMI 集成** — 自动检测系统当前 DNS 设置
+- **合规报告** — 生成审计就绪的 PDF/Excel 报告
+- **SLA 验证** — 跟踪正常运行时间和性能阈值
+
+**示例：**
+
+```bash
+# 验证 DNS 迁移
+net-benchmark dns benchmark \
+  --resolvers old-provider.json,new-provider.json \
+  --zone-transfer \ # 即将推出
+  --output migration-report/ \
+  --formats pdf,excel
+```
+
+</details>
+
+<details>
+<summary><b>📊 分析与报告特性</b></summary>
+
+<br>
+
+- **按域名统计** — 分析每个域名的性能
+- **按记录类型统计** — 比较 A、AAAA、MX、TXT 等
+- **错误分类** — 统计错误类型
+- **对比矩阵** — 解析器并排对比
+- **趋势分析** — 多次运行下的性能变化
+- **按条件找最佳** — 按延迟/可靠性/稳定性找出最佳解析器
+
+**示例：**
+
+```bash
+# 详细分析
+net-benchmark dns benchmark \
+  --use-defaults \
+  --formats csv,excel \
+  --domain-stats \
+  --record-type-stats \
+  --error-breakdown \
+  --formats csv,excel,pdf
+```
+
+</details>
+
+<details>
+<summary><b>🌐 国际化与兼容性</b></summary>
+
+<br>
+
+- **IDNA 支持** — 国际化域名 (IDN)
+- **多种记录类型** — A, AAAA, MX, TXT, CNAME, NS, SOA, PTR, SRV, CAA
+- **跨平台** — Linux, macOS, Windows（原生支持）
+- **CI/CD 集成** — JSON 输出、正确的退出码、静默模式
+- **自定义解析器** — 从 JSON 加载，测试自己的 DNS 服务器
+- **自定义域名** — 针对特定域名列表进行测试
+
+**示例：**
+
+```bash
+# 测试国际化域名
+net-benchmark dns benchmark \
+  --domains international-domains.txt \
+  --record-types A,AAAA,MX \
+  --resolvers custom-resolvers.json
+```
+
+</details>
+
+> 💡 **大多数用户只需要基础功能。** 这些高级特性在你需要时随手可用。
+
+---
+
+#### 💼 使用场景
+
+##### 🔧 开发者：优化 API 性能
+
+```bash
+# 找到 API 端点最快的 DNS
+net-benchmark dns benchmark \
+  --domains api.myapp.com,cdn.myapp.com \
+  --record-types A,AAAA \
+  --resolvers production.json \
+  --iterations 10
+```
+
+**结果：** API 延迟降低 100-300ms
+
+---
+
+##### 🛡️ DevOps/SRE：迁移前验证
+
+```bash
+# 在切换 DNS 服务商前测试新旧解析器
+net-benchmark dns benchmark \
+  --resolvers current-dns.json,new-dns.json \
+  --use-defaults \
+  --dnssec-validate \
+  --output migration-report/ \
+  --formats csv,excel
+```
+
+**结果：** 迁移前验证性能和安全
+
+---
+
+##### 🏠 自建 DNS 用户：证明 Pi-hole 性能
+
+```bash
+# 对比 Pi-hole 与公共 DNS
+net-benchmark dns compare \
+  --resolvers pihole.local,1.1.1.1,8.8.8.8,9.9.9.9 \
+  --domains common-sites.txt \
+  --rounds 10
+```
+
+**结果：** 用数据证明自建 DNS 是否真的更快
+
+---
+
+##### 📊 网络管理员：自动化健康检查
+
+```bash
+# 加入 crontab 每月生成报告
+0 0 1 * * net-benchmark dns benchmark \
+  --use-defaults \
+  --output /var/reports/dns/ \
+  --formats excel,csv \
+  --domain-stats \
+  --error-breakdown
+```
+
+**结果：** 自动化的合规和 SLA 报告
+
+---
+
+##### 🔐 隐私倡导者：测试加密 DNS
+
+```bash
+# 基准测试注重隐私的 DoH/DoT 解析器
+net-benchmark dns benchmark \
+  --doh \
+  --resolvers privacy-resolvers.json \
+  --domains sensitive-sites.txt \
+  --dnssec-validate
+```
+
+**结果：** 找到最快的加密 DNS，同时不牺牲隐私
+
+---
+
+#### 📖 使用示例
+
+##### 基本用法
+
+```bash
+# 带进度条的基本测试
+net-benchmark dns benchmark --use-defaults --formats csv,excel
+
+# 静默模式（无进度条）
+net-benchmark dns benchmark --use-defaults --formats csv,excel --quiet
+
+# 自定义解析器和域名
+net-benchmark dns benchmark --resolvers data/resolvers.json --domains data/domains.txt
+
+# 仅 CSV 的快速测试
+net-benchmark dns benchmark --use-defaults --formats csv
+```
+
+##### 高级用法
+
+```bash
+# 导出机器可读的 JSON 包
+net-benchmark dns benchmark --use-defaults --json --output ./results
+
+# 测试特定记录类型
+net-benchmark dns benchmark --use-defaults --formats csv,excel --record-types A,AAAA,MX
+
+# 自定义输出位置和格式
+net-benchmark dns benchmark \
+  --use-defaults \
+  --output ./my-results \
+  --formats csv,excel
+
+# 包含详细统计
+net-benchmark dns benchmark \
+  --use-defaults \
+  --formats csv,excel \
+  --record-type-stats \
+  --error-breakdown
+
+# 高并发+重试
+net-benchmark dns benchmark \
+  --use-defaults \
+  --formats csv,excel \
+  --max-concurrent 200 \
+  --timeout 3.0 \
+  --retries 3
+
+# 网站迁移计划
+net-benchmark dns benchmark \
+  --resolvers data/global_resolvers.json \
+  --domains data/migration_domains.txt \
+  --formats excel,pdf \
+  --output ./migration_analysis
+
+# DNS 服务商选型
+net-benchmark dns benchmark \
+  --resolvers data/provider_candidates.json \
+  --domains data/business_domains.txt \
+  --formats csv,excel \
+  --output ./provider_selection
+
+# 网络排错
+net-benchmark dns benchmark \
+  --resolvers "192.168.1.1,1.1.1.1,8.8.8.8" \
+  --domains "problematic-domain.com,working-domain.com" \
+  --timeout 10 \
+  --retries 3 \
+  --formats csv \
+  --output ./troubleshooting
+
+# 安全评估
+net-benchmark dns benchmark \
+  --resolvers data/security_resolvers.json \
+  --domains data/security_test_domains.txt \
+  --formats pdf \
+  --output ./security_assessment
+
+# 性能监控
+net-benchmark dns benchmark \
+  --use-defaults \
+  --formats csv \
+  --quiet \
+  --output /var/log/net_benchmark/$(date +%Y%m%d_%H%M%S)
+```
+
+#### 解析器和域名的内联输入支持
+
+该功能完整支持用逗号分隔的内联值来指定 `--resolvers` 和 `--domains`。
+
+##### 新能力
+
+1. **内联解析器**: `--resolvers "1.1.1.1,8.8.8.8,9.9.9.9"`
+2. **内联域名**: `--domains "google.com,github.com"`
+3. **单个值**: `--resolvers "1.1.1.1"` 或 `--domains "google.com"`
+4. **命名解析器**: `--resolvers "cloudflare,google,quad9"`
+5. **混合输入**: `--resolvers "1.1.1.1,cloudflare,8.8.8.8"`
+
+##### 向下兼容
+
+- 所有基于文件的配置依然可用
+- CLI 无破坏性变更
+- 文件检测优先于内联解析
+
+##### 使用示例
+
+###### 之前（只有文件可以工作）
+
+```bash
+net-benchmark dns benchmark \
+    --resolvers data/resolvers.json \
+    --domains data/domains.txt
+```
+
+###### 之后（两者都可以）
+
+```bash
+# 内联（新方式）
+net-benchmark dns benchmark \
+    --resolvers "1.1.1.1,8.8.8.8,9.9.9.9" \
+    --domains "google.com,github.com" \
+    --timeout 10 \
+    --retries 3 \
+    --formats csv \
+    --output ./troubleshooting
+
+# 文件（依然有效）
+net-benchmark dns benchmark \
+    --resolvers data/resolvers.json \
+    --domains data/domains.txt \
+    --formats csv
+```
+
+###### 命名解析器
+
+```bash
+net-benchmark dns benchmark \
+    --resolvers "Cloudflare,Google,Quad9" \
+    --domains "google.com,github.com" \
+    --timeout 10 \
+    --retries 3 \
+    --formats csv \
+    --output ./troubleshooting_named
+```
+
+###### 混合输入
+
+```bash
+net-benchmark dns benchmark \
+    --resolvers "1.1.1.1,Cloudflare,8.8.8.8" \
+    --domains "google.com,github.com" \
+    --timeout 10 \
+    --retries 3 \
+    --formats csv \
+    --output ./troubleshooting_mixed
+```
+
+###### 单个
+
+```bash
+net-benchmark dns benchmark \
+    --resolvers "1.1.1.1" \
+    --domains "google.com" \
+    --timeout 10 \
+    --retries 3 \
+    --formats csv \
+    --output ./troubleshooting
+```
+
+#### 🔧 实用工具
+
+##### 解析器管理
+
+```bash
+# 显示默认解析器和域名
+net-benchmark dns list-defaults
+
+# 浏览所有可用解析器
+net-benchmark dns list-resolvers
+
+# 详细信息
+net-benchmark dns list-resolvers --details
+
+# 按类别筛选
+net-benchmark dns list-resolvers --category security
+net-benchmark dns list-resolvers --category privacy
+net-benchmark dns list-resolvers --category family
+
+# 导出为不同格式
+net-benchmark dns list-resolvers --format csv
+net-benchmark dns list-resolvers --format json
+```
+
+##### 域名管理
+
+```bash
+# 列出所有测试域名
+net-benchmark dns list-domains
+
+# 按类别查看
+net-benchmark dns list-domains --category tech
+net-benchmark dns list-domains --category ecommerce
+net-benchmark dns list-domains --category social
+
+# 限制结果数量
+net-benchmark dns list-domains --count 10
+net-benchmark dns list-domains --category news --count 5
+
+# 导出域名列表
+net-benchmark dns list-domains --format csv
+net-benchmark dns list-domains --format json
+```
+
+##### 类别概览
+
+```bash
+# 查看所有可用类别
+net-benchmark dns list-categories
+```
+
+##### 配置管理
+
+```bash
+# 生成示例配置
+net-benchmark dns generate-config --output sample_config.yaml
+
+# 按类别生成特定配置
+net-benchmark dns generate-config --category security --output security_test.yaml
+net-benchmark dns generate-config --category family --output family_protection.yaml
+net-benchmark dns generate-config --category performance --output performance_test.yaml
+
+# 为特定场景生成自定义配置
+net-benchmark dns generate-config --category privacy --output privacy_audit.yaml
+```
+
+---
+
+#### 完整使用指南
+
+##### 快速性能测试
+
+```bash
+# 带进度条的基本测试
+net-benchmark dns benchmark --use-defaults
+
+# 静默模式仅 CSV
+net-benchmark dns benchmark --use-defaults --formats csv --quiet
+
+# 指定记录类型
+net-benchmark dns benchmark --use-defaults --record-types A,AAAA,MX
+```
+
+附加分析参数：
+
+```bash
+# 包含域名、记录类型统计和错误分类
+net-benchmark dns benchmark --use-defaults \
+  --domain-stats --record-type-stats --error-breakdown
+```
+
+JSON 导出：
+
+```bash
+# 导出机器可读数据包
+net-benchmark dns benchmark --use-defaults --json --output ./results
+```
+
+##### 网络管理员
+
+```bash
+# 对比内部与外部 DNS
+net-benchmark dns benchmark \
+  --resolvers "192.168.1.1,1.1.1.1,8.8.8.8,9.9.9.9" \
+  --domains "internal.company.com,google.com,github.com,api.service.com" \
+  --formats excel,pdf \
+  --timeout 3 \
+  --max-concurrent 50 \
+  --output ./network_audit
+
+# 测试 DNS 故障转移场景
+net-benchmark dns benchmark \
+  --resolvers data/primary_resolvers.json \
+  --domains data/business_critical_domains.txt \
+  --record-types A,AAAA \
+  --retries 3 \
+  --formats csv,excel \
+  --output ./failover_test
+```
+
+##### ISP 与网络运营商
+
+```bash
+# ISP 解析器综合对比
+net-benchmark dns benchmark \
+  --resolvers data/isp_resolvers.json \
+  --domains data/popular_domains.txt \
+  --timeout 5 \
+  --max-concurrent 100 \
+  --formats csv,excel,pdf \
+  --output ./isp_performance_analysis
+
+# 区域性能测试
+net-benchmark dns benchmark \
+  --resolvers data/regional_resolvers.json \
+  --domains data/regional_domains.txt \
+  --formats excel \
+  --quiet \
+  --output ./regional_analysis
+```
+
+##### 开发者与 DevOps
+
+```bash
+# 测试应用依赖
+net-benchmark dns benchmark \
+  --resolvers "1.1.1.1,8.8.8.8" \
+  --domains "api.github.com,registry.npmjs.org,pypi.org,docker.io,aws.amazon.com" \
+  --formats csv \
+  --quiet \
+  --output ./app_dependencies
+
+# CI/CD 集成测试
+net-benchmark dns benchmark \
+  --resolvers data/ci_resolvers.json \
+  --domains data/ci_domains.txt \
+  --timeout 2 \
+  --formats csv \
+  --quiet
+```
+
+##### 安全审计员
+
+```bash
+# 安全导向的解析器测试
+net-benchmark dns benchmark \
+  --resolvers data/security_resolvers.json \
+  --domains data/malware_test_domains.txt \
+  --formats csv,pdf \
+  --output ./security_audit
+
+# 隐私导向测试
+net-benchmark dns benchmark \
+  --resolvers data/privacy_resolvers.json \
+  --domains data/tracking_domains.txt \
+  --formats excel \
+  --output ./privacy_analysis
+```
+
+##### 企业 IT
+
+```bash
+# 企业网络评估
+net-benchmark dns benchmark \
+  --resolvers data/enterprise_resolvers.json \
+  --domains data/corporate_domains.txt \
+  --record-types A,AAAA,MX,TXT,SRV \
+  --timeout 10 \
+  --max-concurrent 25 \
+  --retries 2 \
+  --formats csv,excel,pdf \
+  --output ./enterprise_dns_audit
+
+# 多地域测试
+net-benchmark dns benchmark \
+  --resolvers data/global_resolvers.json \
+  --domains data/international_domains.txt \
+  --formats excel \
+  --output ./global_performance
+```
+
+#### 🔍 新的 CLI 选项
+
+| 选项 | 描述 | 示例 |
+|---|---|---|
+| `--iterations, -i` | 完整基准测试循环运行 **N 次** | `net-benchmark dns benchmark --use-defaults -i 3` |
+| `--use-cache` | 允许跨迭代重用缓存结果 | `net-benchmark dns benchmark --use-defaults -i 3 --use-cache` |
+| `--warmup` | 运行**完整预热**（所有解析器 × 域名 × 记录类型） | `net-benchmark dns benchmark --use-defaults --warmup` |
+| `--warmup-fast` | 运行**轻量级预热**（每个解析器一次探测） | `net-benchmark dns benchmark --use-defaults --warmup-fast` |
+| `--include-charts` | 在 PDF/Excel 报告中嵌入图表 | `net-benchmark dns benchmark --use-defaults --formats pdf,excel --include-charts` |
+
+---
+
+#### ⚡ CLI 命令详解
+
+##### 🚀 Top
+
+快速按速度和可靠性对解析器排名。
+
+```bash
+# 快速排名
+net-benchmark dns top
+
+# 使用自定义域名列表
+net-benchmark dns top -d domains.txt
+
+# 导出结果为 JSON
+net-benchmark dns top -o results.json
+```
+
+---
+
+##### 📊 Compare
+
+并排对比解析器，提供详细统计。
+
+```bash
+# 对比 Cloudflare、Google 和 Quad9
+net-benchmark dns compare Cloudflare Google Quad9
+
+# 按 IP 地址对比
+net-benchmark dns compare 1.1.1.1 8.8.8.8 9.9.9.9
+
+# 显示详细的每个域名分解
+net-benchmark dns compare Cloudflare Google --show-details
+
+# 导出为 CSV
+net-benchmark dns compare Cloudflare Google -o results.csv
+```
+
+---
+
+##### 🔄 Monitoring
+
+持续监控解析器性能并支持告警。
+
+```bash
+# 持续监控默认解析器（每 60 秒）
+net-benchmark dns monitoring --use-defaults
+
+# 使用自定义解析器和域名
+net-benchmark dns monitoring -r resolvers.json -d domains.txt
+
+# 运行监控 1 小时并设置告警
+net-benchmark dns monitoring --use-defaults --interval 30 --duration 3600 \
+  --alert-latency 150 --alert-failure-rate 5 --output monitor.log
+```
+
+---
+
+##### 🌟 命令展示
+
+| 命令 | 目的 | 典型用例 | 关键选项 | 输出 |
+|---|---|---|---|---|
+| **top** | 按速度和可靠性快速排名 | 快速查看当前哪个解析器最好 | `--domains`, `--record-types`, `--output` | 解析器排序列表，含延迟和成功率 |
+| **compare** | 特定解析器的并排对比 | 对选定解析器/域名进行详细基准测试 | `--domains`, `--record-types`, `--iterations`, `--output`, `--show-details` | 解析器对比表，含延迟、成功率、按域名分解 |
+| **monitoring** | 持续监控并告警 | 实时跟踪解析器性能随时间的变化 | `--interval`, `--duration`, `--alert-latency`, `--alert-failure-rate`, `--output`, `--use-defaults` | 实时状态指示器、告警、可选日志文件 |
+
+---
+
+#### 📊 分析增强
+
+- **迭代次数**：当运行多于一次迭代时显示。  
+- **缓存命中**：显示有多少查询来自缓存（当启用 `--use-cache` 时）。  
+- **失败跟踪**：统计重复出错的解析器，可通过 `get_failed_resolvers()` 检查。  
+- **缓存统计**：通过 `get_cache_stats()` 获取，显示缓存条目数和缓存是否启用。  
+- **预热结果**：预热查询在原始数据中标记为 `iteration=0`，便于在分析时过滤。
+
+示例汇总输出：
+
+```markdown
+
+=== 基准测试汇总 ===
+总查询数: 150
+成功: 140 (93.33%)
+平均延迟: 212.45 ms
+中位延迟: 198.12 ms
+最快解析器: Cloudflare
+最慢解析器: Quad9
+迭代次数: 3
+缓存命中: 40 (26.7%)
+```
+
+#### ⚡ 最佳实践
+
+| 模式 | 推荐参数 | 目的 |
+|---|---|---|
+| **快速运行** | `--iterations 1 --timeout 1 --retries 0 --warmup-fast` | 快速反馈，最少重试，轻量预热。适合快速检查。 |
+| **完整测试** | `--iterations 3 --use-cache --warmup --timeout 5 --retries 2` | 多次迭代，启用缓存，完整预热。适合详细基准测试。 |
+| **调试模式** | `--iterations 1 --timeout 10 --retries 0 --quiet` | 长超时，无重试，最少输出。适合诊断解析器问题。 |
+| **均衡模式** | `--iterations 2 --use-cache --warmup-fast --timeout 2 --retries 1` | 折中方案：速度适中，少量重试，缓存启用，快速预热。 |
+
+#### ⚙️ 配置文件
+
+##### 解析器 JSON 格式
+
+```json
+{
+  "resolvers": [
+    {
+      "name": "Cloudflare",
+      "ip": "1.1.1.1",
+      "ipv6": "2606:4700:4700::1111"
+    },
+    {
+      "name": "Google DNS",
+      "ip": "8.8.8.8",
+      "ipv6": "2001:4860:4860::8888"
+    }
+  ]
+}
+```
+
+##### 域名文本文件格式
+
+```txt
+# 热门网站
+google.com
+github.com
+stackoverflow.com
+
+# 企业域名
+microsoft.com
+apple.com
+amazon.com
+
+# CDN 和云
+cloudflare.com
+aws.amazon.com
+```
+
+---
+
+#### 性能优化
+
+```bash
+# 大规模测试（1000+ 查询）
+net-benchmark dns benchmark \
+  --resolvers data/many_resolvers.json \
+  --domains data/many_domains.txt \
+  --max-concurrent 50 \
+  --timeout 3 \
+  --quiet \
+  --formats csv
+
+# 不稳定网络环境
+net-benchmark dns benchmark \
+  --resolvers data/backup_resolvers.json \
+  --domains data/critical_domains.txt \
+  --timeout 10 \
+  --retries 3 \
+  --max-concurrent 10
+
+# 快速诊断
+net-benchmark dns benchmark \
+  --resolvers "1.1.1.1,8.8.8.8" \
+  --domains "google.com,cloudflare.com" \
+  --formats csv \
+  --quiet \
+  --timeout 2
+```
+
+---
+
+#### 故障排除
+
+```bash
+# 命令未找到
+pip install -e .
+python -m net_benchmark.dns_benchmark.cli --help
+
+# PDF 生成失败 (Ubuntu/Debian) – 参见 [PDF 依赖](#pdf-dependencies)
+sudo apt-get install libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+  libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+# 或者跳过 PDF
+net-benchmark dns benchmark --use-defaults --formats csv,excel
+
+# 网络超时
+net-benchmark dns benchmark --use-defaults --timeout 10 --retries 3
+net-benchmark dns benchmark --use-defaults --max-concurrent 25
+```
+
+##### 调试模式
+
+```bash
+# 详细运行
+python -m net_benchmark.dns_benchmark.cli benchmark --use-defaults --formats csv
+
+# 最小化配置
+net-benchmark dns benchmark --resolvers "1.1.1.1" --domains "google.com" --formats csv
+```
+
+---
+
+#### 自动化与 CI
+
+##### Cron 定时任务
+
+```bash
+# 每日监控
+0 2 * * * /usr/local/bin/net-benchmark dns benchmark --use-defaults --formats csv --quiet --output /var/log/net_benchmark/daily_$(date +\%Y\%m\%d)
+
+# 每 6 小时按时间段测试
+0 */6 * * * /usr/local/bin/net-benchmark dns benchmark --use-defaults --formats csv --quiet --output /var/log/net_benchmark/$(date +\%Y\%m\%d_\%H)
+```
+
+##### GitHub Actions 示例
+
+```yaml
+- name: DNS 性能测试
+  run: |
+    pip install net-benchmark
+    net-benchmark dns benchmark \
+      --resolvers "1.1.1.1,8.8.8.8" \
+      --domains "api.service.com,database.service.com" \
+      --formats csv \
+      --quiet
+```
+
+---
+
+#### 截图
+
+图片请放在 `src/net_benchmark/dns_benchmark/docs/screenshots/` 下：
+
+- `src/net_benchmark/dns_benchmark/docs/screenshots/cli_run.png`
+- `src/net_benchmark/dns_benchmark/docs/screenshots/excel_report.png`
+- `src/net_benchmark/dns_benchmark/docs/screenshots/pdf_summary.png`
+- `src/net_benchmark/dns_benchmark/docs/screenshots/pdf_charts.png`
+- `src/net_benchmark/dns_benchmark/docs/screenshots/excel_charts.png`
+- `src/net_benchmark/dns_benchmark/docs/screenshots/real_time_monitoring.png`
+
+##### 1. CLI 基准测试运行
+
+[![CLI 基准测试运行](src/net_benchmark/dns_benchmark/docs/screenshots/cli_run.png)](https://github.com/net-benchmark/net-benchmark)
+
+##### 2. Excel 报告输出
+
+[![Excel 报告输出](src/net_benchmark/dns_benchmark/docs/screenshots/excel_report.png)](https://github.com/net-benchmark/net-benchmark)
+
+##### 3. PDF 执行摘要
+
+[![PDF 执行摘要](src/net_benchmark/dns_benchmark/docs/screenshots/pdf_summary.png)](https://github.com/net-benchmark/net-benchmark)
+
+##### 4. PDF 图表
+
+[![PDF 图表](src/net_benchmark/dns_benchmark/docs/screenshots/pdf_charts.png)](https://github.com/net-benchmark/net-benchmark)
+
+##### 5. Excel 图表
+
+[![Excel 图表](src/net_benchmark/dns_benchmark/docs/screenshots/excel_charts.png)](https://github.com/net-benchmark/net-benchmark)
+
+##### 6. 实时监控
+
+[![实时监控](src/net_benchmark/dns_benchmark/docs/real_time_tracking.gif)](https://github.com/net-benchmark/net-benchmark)
+
+#### 获取帮助
+
+```bash
+net-benchmark dns --help
+net-benchmark dns benchmark --help
+net-benchmark dns list-resolvers --help
+net-benchmark dns list-domains --help
+net-benchmark dns list-categories --help
+net-benchmark dns generate-config --help
+```
+
+常见场景：
+
+```bash
+# 我是新手——从哪里开始？
+net-benchmark dns list-defaults
+net-benchmark dns benchmark --use-defaults
+
+# 测试特定解析器
+net-benchmark dns list-resolvers --category security
+net-benchmark dns benchmark --resolvers data/security_resolvers.json --use-defaults
+
+# 生成管理报告
+net-benchmark dns benchmark --use-defaults --formats excel,pdf \
+  --domain-stats --record-type-stats --error-breakdown --json \
+  --output ./management_report
+```
+
+---
+
+#### ❓ 常见问题
+
+<details>
+<summary><b>为什么我的 ISP DNS 不是最快的？</b></summary>
+
+本地 ISP DNS 通常有缓存优势，但可能缺少：
+- 全球 anycast 网络（对远距离域名更慢）
+- DNSSEC 验证
+- 隐私特性（DoH/DoT）
+- 可靠性保证
+
+测试后再根据你的优先级选择！
+
+</details>
+
+<details>
+<summary><b>我应该多久进行一次 DNS 基准测试？</b></summary>
+
+- **一次性**：选择 DNS 服务商时
+- **每月**：网络健康检查
+- **迁移前**：切换服务商时
+- **遇到问题后**：排查性能问题
+
+</details>
+
+<details>
+<summary><b>我可以测试自己的 DNS 服务器吗？</b></summary>
+
+当然可以！只需将其添加到自定义解析器 JSON 文件：
+
+```json
+{
+  "resolvers": [
+    {"name": "我的 DNS", "ip": "192.168.1.1"}
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary><b>在生产环境中使用这个工具安全吗？</b></summary>
+
+是的！该工具仅执行 DNS 查询（读操作），不会：
+- 修改 DNS 记录
+- 发起攻击
+- 将数据发送到外部服务器
+
+所有测试都是任何 DNS 解析器每天都会处理的标准查询。
+
+</details>
+
+<details>
+<summary><b>为什么每次运行的结果会变化？</b></summary>
+
+DNS 性能受以下因素影响而变化：
+- 网络状况
+- DNS 缓存（解析器和中间环节）
+- 服务器负载
+- 地理路由变化
+
+运行多次迭代（`--iterations 5`）以获得更稳定的结果。
+
+</details>
+
+</details>
+
+---
+
+### HTTP 基准测试
+
+<details open>
+<summary><strong>HTTP 基准测试</strong> — 延迟、TTFB、安全头、CDN 指纹、TLS 证书</summary>
+
+#### 🎯 为什么需要这个工具？
+
+每个 HTTP 请求背后都隐藏着十多个性能和安全信号——DNS、TCP、TLS、重定向、压缩、缓存、CDN 路由以及服务器软件。  
+大多数工具只测量总延迟。net‑benchmark 给你完整的图景。
+
+##### 问题
+
+- ⏱️ **隐藏的瓶颈** — 延迟究竟来自 DNS、TCP、TLS 还是服务器自身？
+- 🔗 **静默重定向** — 每次跳转都会增加你看不到的延迟（除非有每跳计时）
+- 🔒 **缺失的安全头** — CSP、HSTS、X‑Frame‑Options 经常缺失
+- 🕵️ **未知 CDN** — 究竟哪个 CDN 正在为你提供服务？
+- 📜 **过期的证书** — 很难在影响生产环境前被发现
+
+##### 解决方案
+
+net‑benchmark 帮你：
+
+- 🔍 **分解每次请求** — DNS → TCP → TLS → TTFB → TTLB，精确到毫秒
+- 📊 **获取真实统计数据** — P95、P99、抖动、一致性评分
+- 🛡️ **审计安全性** — HSTS、CSP、X‑Frame‑Options、CDN 指纹、服务器头信息泄露
+- 📜 **捕获 TLS 证书** — 剩余有效期、CN、颁发者、SAN、通配符检测
+- 🚀 **大规模测试** — 数秒内完成 50+ 并发请求
+
+##### 谁适合用？
+
+- ✅ **开发者** — 优化 API 性能
+- ✅ **DevOps/SRE** — 验证 CDN 和源站 SLA
+- ✅ **安全工程师** — 审计 HTTP 安全头和 TLS 卫生
+- ✅ **API 提供者** — 带认证、头信息和请求体的端点基准测试
+
+---
+
+#### 快速开始
+
+```bash
+# 使用内置的 5 个目标进行单次迭代测试
+net-benchmark http benchmark --use-defaults
+```
+
+结果会自动保存到 `./benchmark_results/`，包含汇总 CSV、详细原始数据，以及可选的 PDF/Excel 报告。
+
+```bash
+# 首次运行推荐
+net-benchmark http benchmark --use-defaults --formats csv,excel
+net-benchmark http benchmark --use-defaults --iterations 5   # 获得有意义的抖动/一致性数据
+```
+
+---
+
+#### ⚡ 命令一览
+
+| 命令 | 功能 | 快速示例 |
+|---|---|---|
+| `benchmark` | 完整 HTTP 基准测试并导出 | `net-benchmark http benchmark --use-defaults` |
+| `top` | 按速度对目标排名 | `net-benchmark http top --limit 5` |
+| `compare` | 并排对比目标 | `net-benchmark http compare api.example.com api2.example.com` |
+| `monitoring` | 持续监控并告警 | `net-benchmark http monitoring --use-defaults` |
+
+```bash
+# 立刻找出当前最快的端点
+net-benchmark http top --limit 5
+
+# 并排对比两个 API
+net-benchmark http compare api.example.com api2.example.com --iterations 3 --show-details
+
+# 持续监控 1 小时并设置告警
+net-benchmark http monitoring --use-defaults \
+  --interval 30 --duration 3600 \
+  --alert-latency 500 --alert-failure-rate 5
+```
+
+---
+
+#### ✨ 核心特性
+
+##### 🚀 性能
+
+- **异步引擎** — httpx 支持 HTTP/2、连接池、信号量并发控制
+- **计时分解** — DNS 解析、TCP 连接、TLS 握手、TTFB、TTLB、总延迟
+- **多次迭代** — 多次运行以获得统计精度
+- **统计分析** — 均值、中位数、P95、P99、抖动、一致性评分
+- **指数退避重试** — 失败时指数退避（与 DNS 引擎一致）
+- **可配置并发** — 控制最大并发请求数
+- **预热阶段** — 可选的 HEAD 或完整预热后再进行测量
+
+##### 🔒 安全与 TLS
+
+- **安全头审计** — HSTS、CSP、X‑Frame‑Options、X‑Content‑Type‑Options、Referrer‑Policy、Permissions‑Policy
+- **CDN 指纹识别** — 检测 Cloudflare、CloudFront、Fastly、Akamai、Google、Azure CDN
+- **服务器头信息泄露检测** — 标记软件/版本信息披露
+- **内联 TLS 证书捕获** — 剩余有效期、CN、颁发者、SAN、通配符检测
+- **降级检测** — HTTPS→HTTP 重定向链以及 HTTP/2→HTTP/1.1 回退
+- **IPv4 vs IPv6** — 每请求双栈检测
+- **Alt‑Svc 检测** — 服务器是否声明 HTTP/3
+
+##### 🔐 认证与企业
+
+- **基本认证、Bearer Token、自定义 API Key** — `--auth basic:user:pass`, `--auth bearer:token`, `--headers x-api-key:key`
+- **mTLS 客户端证书** — `--cert` + `--cert-key`
+- **代理支持** — `--proxy http://proxy:8080`
+- **SNI 覆盖** — `--sni example.com`
+- **接口绑定** — `--local-address 192.168.1.100`
+- **请求 ID 注入** — `--inject-request-id` 添加 X‑Request‑ID 头
+- **自定义 User‑Agent** — `--user-agent "MyBot/1.0"`
+- **Cookies** — 可重复使用的 `--cookie "name=value"` 参数
+
+##### 🧪 断言与验证
+
+- **断言状态码** — `--assert status=200`
+- **断言响应体包含** — `--assert body_contains=success`
+- **断言头存在** — `--assert header_exists=X-Cache`
+- **断言头值** — `--assert header_value=X-Cache=HIT`
+- **断言最大延迟** — `--assert max_latency=500`
+- **断言 Content‑Type** — `--assert content_type=application/json`
+- **断言响应大小** — `--assert response_size_min=100`, `--assert response_size_max=10000`
+
+##### 📊 分析与导出
+
+- **多种格式** — CSV、Excel、PDF、JSON（参见 [导出格式](#导出格式)）
+- **可视化报告** — Excel/PDF 中的图表
+- **每目标统计** — 延迟、TTFB、HTTP/2 比例、重定向率、压缩后大小
+- **缓存头分析** — Cache‑Control、ETag、Last‑Modified、Age 是否存在
+- **状态码分布** — 2xx/3xx/4xx/5xx 细分
+- **错误分类** — 识别有问题的目标
+
+---
+
+#### 🔧 HTTP/2、重定向与降级检测
+
+| 功能 | 捕获内容 |
+|---|---|
+| HTTP/2 协商 | 每个请求的 ALPN 结果（`h2` 或 `http/1.1`） |
+| HTTP/2 降级检测 | 标记预期 HTTP/2 但协商为 HTTP/1.1 的情况 |
+| 重定向链 | 完整的跳转列表，包含每跳 URL、状态码和耗时 |
+| 降级检测 | 标记任何 HTTPS→HTTP 重定向 |
+| 压缩后大小 | 捕获 Content‑Length 头用于带宽分析 |
+
+```bash
+# 强制 HTTP/1.1 以比较性能
+net-benchmark http benchmark --use-defaults --no-http2
+
+# 观察重定向链
+net-benchmark http benchmark --targets https://github.com --iterations 1
+
+# 检测 HTTP/2 降级（在企业代理后尤其有用）
+net-benchmark http benchmark --use-defaults --iterations 3
+```
+
+---
+
+#### 🔒 安全与认证示例
+
+```bash
+# 基本认证
+net-benchmark http benchmark \
+  --targets https://httpbin.org/basic-auth/user/pass \
+  --auth "basic:user:pass"
+
+# Bearer Token（标准 OAuth2）
+net-benchmark http benchmark \
+  --targets https://api.example.com/data \
+  --auth "bearer:sk-abc123"
+
+# 自定义 API Key 头（x‑api‑key）
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --headers "x-api-key:sk-abc123"
+
+# mTLS 客户端证书
+net-benchmark http benchmark \
+  --targets https://mtls.example.com \
+  --cert client.pem --cert-key client-key.pem
+
+# 带认证的代理
+net-benchmark http benchmark \
+  --targets https://example.com \
+  --proxy http://proxy:8080 \
+  --auth "basic:proxyuser:proxypass"
+```
+
+---
+
+#### 💼 使用场景
+
+##### 🔧 开发者：优化 API 性能
+
+```bash
+# 找到最快的端点并分解计时
+net-benchmark http benchmark \
+  --targets https://api.myapp.com/v1/users,https://api.myapp.com/v2/users \
+  --method GET \
+  --headers "Authorization:Bearer token" \
+  --iterations 5
+```
+
+**结果：** 精确定位 DNS、TCP、TLS 还是服务器逻辑是瓶颈。
+
+---
+
+##### 🛡️ DevOps/SRE：验证 CDN 迁移
+
+```bash
+# 对比旧源站与新 CDN
+net-benchmark http compare \
+  https://origin.example.com \
+  https://cdn.example.com \
+  --iterations 5 --show-details
+```
+
+**结果：** 数据驱动地证明 CDN 是否（或不是）更快。
+
+---
+
+##### 🔐 安全工程师：审计公共端点
+
+```bash
+# 全量安全审计并带断言
+net-benchmark http benchmark \
+  --targets https://www.example.com,https://api.example.com \
+  --assert status=200 \
+  --assert header_exists=strict-transport-security \
+  --assert header_value=X-Content-Type-Options=nosniff \
+  --formats excel,pdf \
+  --output ./security_audit
+```
+
+**结果：** 即时生成安全头覆盖率和 TLS 证书健康报告卡。
+
+---
+
+##### 🏢 企业：自动化健康检查
+
+```bash
+# 加入 crontab 每小时生成报告
+0 * * * * net-benchmark http benchmark \
+  --targets targets.txt \
+  --assert status=200 --assert max_latency=1000 \
+  --formats csv --quiet \
+  --output /var/reports/http/$(date +\%Y\%m\%d_\%H)
+```
+
+**结果：** 自动化的 SLA 合规和性能趋势报告。
+
+---
+
+#### 📖 使用示例
+
+##### 基本用法
+
+```bash
+# 测试内置默认目标
+net-benchmark http benchmark --use-defaults
+
+# 从文件加载自定义目标
+net-benchmark http benchmark --targets ./targets.txt
+
+# 内联目标（逗号分隔）
+net-benchmark http benchmark --targets "https://example.com,https://httpbin.org/get"
+
+# 快速测试，仅 CSV 输出
+net-benchmark http benchmark --use-defaults --formats csv --quiet
+
+# 多次迭代以获得统计精度
+net-benchmark http benchmark --use-defaults --iterations 5
+
+# 自定义 HTTP 方法并发送请求体
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --body '{"action":"test"}'
+
+# 从文件读取请求体
+echo '{"name":"test","value":42}' > payload.json
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --body-file payload.json
+```
+
+##### 高级用法
+
+```bash
+# 导出所有格式并包含图表
+net-benchmark http benchmark \
+  --use-defaults \
+  --formats csv,excel,pdf \
+  --include-charts \
+  --json \
+  --output ./full_report
+
+# 独立控制各个超时
+net-benchmark http benchmark \
+  --targets https://slow-api.example.com \
+  --connect-timeout 5 --read-timeout 30 --write-timeout 10
+
+# 不修改 URL 直接添加查询参数
+net-benchmark http benchmark \
+  --targets https://api.example.com/search \
+  --params "page=1,limit=50,q=test"
+
+# 高并发并预热
+net-benchmark http benchmark \
+  --use-defaults \
+  --max-concurrent 100 \
+  --warmup-fast \
+  --iterations 3
+
+# 完整的断言套件
+net-benchmark http benchmark \
+  --targets https://api.example.com/health \
+  --assert status=200 \
+  --assert body_contains=ok \
+  --assert max_latency=500 \
+  --assert content_type=application/json \
+  --assert response_size_min=10
+```
+
+##### CI/CD 集成
+
+```yaml
+- name: HTTP 端点健康检查
+  run: |
+    pip install net-benchmark
+    net-benchmark http benchmark \
+      --targets "https://api.prod.example.com/health,https://web.prod.example.com" \
+      --assert status=200 \
+      --assert max_latency=1000 \
+      --formats csv \
+      --quiet
+```
+
+---
+
+#### ⚡ CLI 命令详解
+
+##### 🚀 Top
+
+按速度或可靠性快速对目标排名。
+
+```bash
+# 按延迟对默认目标排名
+net-benchmark http top --use-defaults --limit 5
+
+# 按 TTFB 排名
+net-benchmark http top --use-defaults --limit 5 --metric ttfb
+
+# 按成功率排名
+net-benchmark http top --targets targets.txt --limit 10 --metric success
+```
+
+---
+
+##### 📊 Compare
+
+并排对比特定目标，提供详细统计。
+
+```bash
+# 对比两个目标
+net-benchmark http compare https://example.com https://httpbin.org/get
+
+# 自动补全 scheme（缺失时添加 https://）
+net-benchmark http compare api.example.com api2.example.com
+
+# 带认证和多次迭代
+net-benchmark http compare api.example.com api2.example.com \
+  --auth "bearer:token" --iterations 5
+
+# 显示每次迭代的分解
+net-benchmark http compare api.example.com api2.example.com \
+  --iterations 3 --show-details
+
+# 导出对比结果
+net-benchmark http compare api.example.com api2.example.com \
+  --output comparison.csv
+```
+
+---
+
+##### 🔄 Monitoring
+
+持续监控目标并支持可配置告警。
+
+```bash
+# 默认目标每 60 秒监控一次
+net-benchmark http monitoring --use-defaults
+
+# 自定义目标和告警
+net-benchmark http monitoring \
+  --targets targets.txt \
+  --interval 30 \
+  --duration 3600 \
+  --alert-latency 500 \
+  --alert-failure-rate 5 \
+  --output ./monitoring_logs
+
+# 通过代理监控
+net-benchmark http monitoring \
+  --targets https://internal-api.example.com \
+  --proxy http://proxy:8080 \
+  --interval 60
+```
+
+---
+
+##### 🌟 命令展示
+
+| 命令 | 目的 | 典型用例 | 关键选项 | 输出 |
+|---|---|---|---|---|
+| **top** | 按速度/可靠性快速排名 | 快速查看当前哪个端点最好 | `--limit`, `--metric`, `--iterations` | 包含延迟和成功率的排序列表 |
+| **compare** | 特定目标的并排对比 | 对选定端点进行详细基准测试 | `--iterations`, `--show-details`, `--output` | 包含延迟、TTFB、成功率和每次迭代分解的对比表 |
+| **monitoring** | 持续监控并告警 | 实时跟踪端点健康状态随时间的变化 | `--interval`, `--duration`, `--alert-latency`, `--alert-failure-rate`, `--output` | 实时状态、告警、每次间隔的 JSON 快照 |
+
+---
+
+#### ⚡ 最佳实践
+
+| 模式 | 推荐参数 | 目的 |
+|---|---|---|
+| **快速运行** | `--iterations 1 --warmup-fast` | 快速反馈，轻量预热 |
+| **完整测试** | `--iterations 5 --warmup --timeout 10 --retries 2` | 多次迭代，完整预热，适合详细基准测试 |
+| **调试模式** | `--iterations 1 --timeout 30 --retries 0` | 长超时，无重试，适合诊断端点问题 |
+| **API 测试** | `--method POST --body '{}' --headers "Auth:token" --assert status=200` | 发送负载并验证响应 |
+
+---
+
+#### 📊 汇总输出示例
+
+```text
+============================================
+| 总请求数:          5                      |
+| 成功:              4 (80.00%)             |
+| 平均延迟:          1047.25 ms             |
+| 平均 TTFB:         772.20 ms              |
+| HTTP/2 比率:       100.0%                 |
+| HSTS 覆盖率:       60.0%                  |
+| 断言通过率:        100.0%                 |
+| 最快目标:          https://www.apple.com  |
+| 最慢目标:          https://www.github.com |
+============================================
+```
+
+---
+
+#### 🔧 故障排除
+
+```bash
+# 命令未找到
+pip install -e .
+python -m net_benchmark.http_bench.cli --help
+
+# PDF 生成失败 (Ubuntu/Debian) — 参见 PDF 依赖
+sudo apt-get install libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+  libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+# 或者跳过 PDF
+net-benchmark http benchmark --use-defaults --formats csv,excel
+
+# 网络超时
+net-benchmark http benchmark --use-defaults --timeout 30 --retries 3
+net-benchmark http benchmark --use-defaults --max-concurrent 10
+
+# 内部服务器 SSL 错误
+net-benchmark http benchmark --targets https://internal.local --no-verify-ssl
+```
+
+---
+
+#### 获取帮助
+
+```bash
+net-benchmark http --help
+net-benchmark http benchmark --help
+net-benchmark http top --help
+net-benchmark http compare --help
+net-benchmark http monitoring --help
+```
+
+常见场景：
+
+```bash
+# 我是新手——从哪里开始？
+net-benchmark http benchmark --use-defaults
+
+# 带认证测试特定 API
+net-benchmark http benchmark \
+  --targets https://api.example.com/echo \
+  --method POST \
+  --headers "x-api-key:sk-abc123" \
+  --body '{"test":true}'
+
+# 生成安全审计报告
+net-benchmark http benchmark \
+  --targets https://www.example.com \
+  --assert status=200 \
+  --assert header_exists=strict-transport-security \
+  --formats excel,pdf \
+  --output ./security_audit
+```
+
+---
+
+#### ❓ 常见问题
+
+**为什么我的 API 比预期慢？**  
+计时分解（DNS → TCP → TLS → TTFB → TTLB）会精确告诉你时间花在哪里。如果 DNS 慢，检查解析器。如果 TLS 慢，检查证书链大小或 OCSP 装订。如果 TTFB 慢，服务器逻辑或数据库是瓶颈。
+
+**我应该多久进行一次 HTTP 基准测试？**  
+- **一次性**：选择 CDN 或 API 提供商时  
+- **每日**：关键生产端点  
+- **部署前**：发现性能回归  
+- **故障后**：验证修复
+
+**可以测试带认证的端点吗？**  
+可以——`--auth basic:user:pass`、`--auth bearer:token` 或 `--headers x-api-key:key` 都支持。mTLS 也可通过 `--cert` 和 `--cert-key` 实现。
+
+**在生产环境使用安全吗？**  
+是的！它只执行标准 HTTP 请求（读操作），不会修改数据、发起攻击或发送数据到外部服务器。
+
+**为什么每次运行结果会变化？**  
+HTTP 性能受网络状况、服务器负载、CDN 路由变化和 TLS 会话恢复的影响。运行多次迭代（`--iterations 5`）以获得更稳定的结果。使用 `--warmup-fast` 来消除冷启动效应。
+
+</details>
+
+---
+
+### SSL 检查
+
+<details>
+<summary><strong>SSL 检查</strong> — 证书到期、链验证 <em>(0.6.0 版本推出)</em></summary>
+
+#### 计划中的功能
+
+- 检查证书到期日期
+- 验证证书链和信任库
+- 监控多台主机并告警
+
+> **状态：** 计划于 0.6.0 版本推出 — [欢迎贡献](CONTRIBUTING.md)
+
+</details>
+
+---
+
+## 导出格式
+
+| 格式 | 参数 | 备注 |
+|--------|------|-------|
+| CSV | `--formats csv` | 原始结果 + 汇总 + 可选的域名/记录类型/错误统计 |
+| Excel | `--formats excel` | 格式化工作簿，含图表和 DNSSEC 工作表 |
+| PDF | `--formats pdf` | 需要 `pip install net-benchmark[pdf]`（见下方） |
+| JSON | `--json` | 完整结构化负载（单独参数） |
+
+### CSV 输出
+
+- 原始数据：带时间戳和元数据的单个查询结果
+- 汇总统计：每个解析器的聚合指标
+- 域名统计：每个域名的指标（当使用 `--domain-stats`）
+- 记录类型统计：每种记录类型的指标（当使用 `--record-type-stats`）
+- 错误分类：按错误类型统计数量（当使用 `--error-breakdown`）
+
+### Excel 报告
+
+- 原始数据表：带格式的所有查询结果
+- 解析器汇总：全面的统计信息，带条件格式
+- 域名统计：每个域名的性能（可选）
+- 记录类型统计：每种记录类型的性能（可选）
+- 错误分类：聚合的错误计数（可选）
+- 性能分析：图表和对比分析
+
+### PDF 报告
+
+- 执行摘要：主要发现和建议
+- 性能图表：延迟对比；可选成功率图表
+- 解析器排名：按平均延迟排序
+- 详细分析：技术深度剖析，含百分位数
+
+### 📄 可选的 PDF 导出
+
+默认情况下，工具支持 **CSV** 和 **Excel** 导出。  
+PDF 导出需要额外依赖 **weasyprint**，为避免在某些平台上产生运行时问题，它不会被自动安装。
+
+### HTTP 专用导出
+
+| CSV 文件 | 内容 |
+|----------|------|
+| `*_raw.csv` | 包含计时分解的单个请求结果 |
+| `*_summary.csv` | 每个目标的聚合统计 |
+| `*_security.csv` | 安全头存在性矩阵 |
+| `*_ttfb.csv` | 首字节时间分析 |
+| `*_protocols.csv` | HTTP/1.1 vs HTTP/2 分布 |
+
+### Excel 报告 (HTTP)
+
+- **Raw Data** 表：所有请求，含计时、安全头、证书详情
+- **Target Summary** 表：每个目标的综合统计
+- **TTFB Analysis** 表：每个目标的 TTFB 百分位数
+- **Security Headers** 表：颜色编码的存在性矩阵
+- **Charts** 表：延迟对比、TTFB 对比、成功率（可选）
+
+#### 安装 PDF 支持
+
+```bash
+pip install net-benchmark[pdf]
+```
+
+#### 使用方法
+
+安装后即可通过 CLI 请求 PDF 输出：
+
+```bash
+net-benchmark dns benchmark --use-defaults --formats pdf --output ./results
+```
+
+如果未安装 `weasyprint` 且请求 PDF 输出，CLI 会显示：
+
+```bash
+[-] Error during benchmark: PDF export requires 'weasyprint'. Install with: pip install net-benchmark[pdf]
+```
+
+### ⚠️ WeasyPrint 环境搭建（用于 PDF 导出） {#pdf-dependencies}
+
+工具使用 **WeasyPrint** 生成 PDF 报告。  
+除了 Python 包，你还需要额外的系统库。
+
+#### 🛠 Linux (Debian/Ubuntu)
+
+```bash
+sudo apt install python3-pip libpango-1.0-0 libpangoft2-1.0-0 \
+  libharfbuzz-subset0 libjpeg-dev libopenjp2-7-dev libffi-dev
+```
+
+#### 🛠 macOS (Homebrew)
+
+```bash
+brew install pango cairo libffi gdk-pixbuf jpeg openjpeg harfbuzz
+```
+
+#### 🛠 Windows
+
+通过以下任一方法安装 GTK+ 库：
+
+- **MSYS2**: [下载 MSYS2](https://www.msys2.org/)，然后运行：
+
+  ```bash
+  pacman -S mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libffi
+  ```
+
+- **GTK+ 64 位安装程序**: [下载 GTK+ Runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases) 并运行安装程序。
+
+安装后请重启终端。
+
+#### ✅ 验证安装
+
+安装系统库后，安装 Python 额外依赖：
+
+```bash
+pip install net-benchmark[pdf]
+```
+
+然后运行：
+
+```bash
+net-benchmark dns benchmark --use-defaults --formats pdf --output ./results
+```
+
+### JSON 导出
+
+- 机器可读数据包，包含：
+  - 总体统计
+  - 解析器统计
+  - 原始查询结果
+  - 域名统计
+  - 记录类型统计
+  - 错误分类
+
+### 生成示例配置
+
+```bash
+net-benchmark dns generate-config \
+  --category privacy \
+  --output my-config.yaml
+```
+
+---
+
+## 发布流程
+
+- **前置条件**
+  - **已配置 GPG 密钥：** 运行 `make gpg-check` 验证。
+  - **分支保护：** main 分支要求签名提交和通过 CI。
+  - **CI 发布：** 在签名 tag（匹配 vX.Y.Z）上触发。
+
+- **准备发布（需签名）**
+  - **补丁/次要/主要版本升级：**
+  
+    ```bash
+    make release-patch      # 或: make release-minor / make release-major
+    ```
+
+    - 更新版本号。
+    - 创建或重用 `release/X.Y.Z` 分支。
+    - 生成签名提交并推送分支。
+  - **发起 PR：** 从 `release/X.Y.Z` 合并到 `main`，CI 通过后合并。
+
+- **打 Tag 并发布**
+  - **创建签名 tag 并推送：**
+
+    ```bash
+    make release-tag VERSION=X.Y.Z
+    ```
+
+    - 在 main 分支上打上 `vX.Y.Z` 签名 tag。
+    - CI 将发布到 PyPI。
+
+- **手动替代方案**
+  - **创建分支并签名提交：**
+  
+    ```bash
+    git checkout -b release/manually-update-version-based-on-release-pattern
+    git add .
+    git commit -S -m "Release release/$NEXT_VERSION"
+    git push origin release/$NEXT_VERSION
+    ```
+
+  - **发起 PR 并合并到 main。**
+  - **然后打 tag：**
+  
+    ```bash
+    make release-tag VERSION=$NEXT_VERSION
+    ```
+
+- **注意**
+  - **签名提交：** `git commit -S ...`
+  - **签名 tag：** `git tag -s vX.Y.Z -m "Release vX.Y.Z"`
+  - **版本号来源：** `pyproject.toml` 和 `src/net_benchmark/__init__.py`
+
+---
+
+## 链接与支持
+
+### 官方
+
+- **GitHub**: [net-benchmark/net-benchmark](https://github.com/net-benchmark/net-benchmark)
+- **PyPI**: [net-benchmark](https://pypi.org/project/net-benchmark)
+
+### 社区
+
+- **讨论**: [GitHub Discussions](https://github.com/net-benchmark/net-benchmark/discussions)
+- **问题反馈**: [Bug Reports](https://github.com/net-benchmark/net-benchmark/issues)
+
+---
+
+## 贡献
+
+欢迎贡献。详见 [CONTRIBUTING.md](CONTRIBUTING.md)。  
+本项目采用 [BDFL 治理模型](GOVERNANCE.md) — @frankovo 对技术方向和发布拥有最终决定权。
+
+---
+
+## 许可证
+
+MIT © [frankovo](https://github.com/frankovo)
+
+> **在找 dns-benchmark-tool？**  
+> 本项目是其继承者。原始项目已归档至  
+> [net-benchmark/dns-benchmark-tool](https://github.com/net-benchmark/dns-benchmark-tool)。
+
+---
+由 [buildtools.net](https://buildtools.net) 提供支持 —  
+web 仪表板、多区域测试和企业功能即将推出。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ keywords = [
 dependencies = [
     "httpx[http2]>=0.28.1,<0.29",
     "dnspython>=2.7,<3.0",       
-    "pandas>=2.0,<3.0",          
-    "aiohttp>=3.8,<4.0",         
+    "pandas>=2.0,<3.0",       
     "click>=8.0,<9.0",           
     "pyfiglet>=1.0,<2.0",        
     "colorama>=0.4,<1.0",        
@@ -35,6 +34,7 @@ dependencies = [
     "tqdm>=4.66,<5.0",           
     "matplotlib>=3.8,<4.0",
     "pillow>=11.0.0,<12.0.0",
+    "cryptography>=42.0,<45.0",
 ]
 
 classifiers = [
@@ -63,6 +63,8 @@ Changelog = "https://github.com/net-benchmark/net-benchmark/blob/main/CHANGELOG.
 
 [project.optional-dependencies]
 pdf = ["weasyprint>=66.0,<67.0"]
+websocket = ["aiohttp>=3.8,<4.0"]
+
 dev = [
     "mypy>=1.8,<2.0",
     "black>=24.0,<26.0",
@@ -86,7 +88,7 @@ net_benchmark = [
 ]
 
 [project.scripts]
-net-benchmark = "net_benchmark.dns_benchmark.cli:cli"
+net-benchmark = "net_benchmark.cli:cli"
 dns-benchmark = "net_benchmark.dns_benchmark.cli:cli"  # backward compat
 
 # -------------------

--- a/src/net_benchmark/cli.py
+++ b/src/net_benchmark/cli.py
@@ -7,7 +7,13 @@ from colorama import Fore, Style, init
 from net_benchmark import __version__
 from net_benchmark.dns_benchmark.cli import dns as dns_group
 from net_benchmark.http_bench.cli import http as http_group
-from net_benchmark.ssl_check.cli import ssl as ssl_group
+
+# from net_benchmark.ssl_check.cli import ssl as ssl_group
+
+try:
+    from net_benchmark.ssl_check.cli import ssl as ssl_group
+except ImportError:
+    ssl_group = None  # type:ignore
 
 # Initialize colorama
 init()
@@ -32,7 +38,8 @@ def cli() -> None:
         print()
 
 
-# Attach sub‑command groups
 cli.add_command(dns_group)
 cli.add_command(http_group)
-cli.add_command(ssl_group)
+# cli.add_command(ssl_group)
+if ssl_group is not None:
+    cli.add_command(ssl_group)

--- a/src/net_benchmark/cli.py
+++ b/src/net_benchmark/cli.py
@@ -14,7 +14,9 @@ from net_benchmark.http_bench.cli import http as http_group
 ssl_group: Optional[click.Group] = None
 
 try:
-    from net_benchmark.ssl_check.cli import ssl as ssl_group  # noqa: F811
+    from net_benchmark.ssl_check.cli import ssl as _ssl  # noqa: F811
+
+    ssl_group = _ssl
 except ImportError:
     pass
 

--- a/src/net_benchmark/cli.py
+++ b/src/net_benchmark/cli.py
@@ -1,0 +1,38 @@
+import os
+
+import click
+import pyfiglet
+from colorama import Fore, Style, init
+
+from net_benchmark import __version__
+from net_benchmark.dns_benchmark.cli import dns as dns_group
+from net_benchmark.http_bench.cli import http as http_group
+from net_benchmark.ssl_check.cli import ssl as ssl_group
+
+# Initialize colorama
+init()
+
+
+@click.group()
+@click.version_option(__version__, prog_name="net-benchmark")
+def cli() -> None:
+    """
+    net-benchmark — DNS, HTTP, and SSL benchmarking suite.
+    CLI entry point.
+    """
+    # Allow suppression of banner for CI/CD
+    if not os.environ.get("NO_BANNER"):
+        print(Fore.GREEN + pyfiglet.figlet_format("net-benchmark") + Style.RESET_ALL)
+        print(Fore.CYAN + "dns · http · ssl benchmarking suite" + Style.RESET_ALL)
+        print(
+            Fore.YELLOW
+            + "https://github.com/net-benchmark/net-benchmark"
+            + Style.RESET_ALL
+        )
+        print()
+
+
+# Attach sub‑command groups
+cli.add_command(dns_group)
+cli.add_command(http_group)
+cli.add_command(ssl_group)

--- a/src/net_benchmark/cli.py
+++ b/src/net_benchmark/cli.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import click
 import pyfiglet
@@ -10,10 +11,12 @@ from net_benchmark.http_bench.cli import http as http_group
 
 # from net_benchmark.ssl_check.cli import ssl as ssl_group
 
+ssl_group: Optional[click.Group] = None
+
 try:
-    from net_benchmark.ssl_check.cli import ssl as ssl_group
+    from net_benchmark.ssl_check.cli import ssl as ssl_group  # noqa: F811
 except ImportError:
-    ssl_group = None  # type:ignore
+    pass
 
 # Initialize colorama
 init()

--- a/src/net_benchmark/dns_benchmark/cli.py
+++ b/src/net_benchmark/dns_benchmark/cli.py
@@ -1,18 +1,14 @@
 import asyncio
 import json
 import math
-import os
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
-import pyfiglet
 from colorama import Fore, Style, init
-from tqdm import tqdm
 
-from net_benchmark import __version__
 from net_benchmark.dns_benchmark.analysis import BenchmarkAnalyzer
 from net_benchmark.dns_benchmark.core import (
     DNSQueryEngine,
@@ -28,6 +24,7 @@ from net_benchmark.dns_benchmark.exporters import (
     ExportBundle,
     PDFExporter,
 )
+from net_benchmark.utils.helpers import create_progress_bar
 from net_benchmark.utils.messages import (
     error,
     info,
@@ -42,37 +39,11 @@ from net_benchmark.utils.protocols import _resolve_protocol_and_doh_urls
 init()
 
 
-@click.group()
-@click.version_option(__version__, prog_name="net-benchmark")
-def cli() -> None:
-    """
-    net-benchmark — DNS, HTTP, and SSL benchmarking suite.
-    CLI entry point.
-    """
-    # Allow suppression of banner for CI/CD
-    if not os.environ.get("NO_BANNER"):
-        print(Fore.GREEN + pyfiglet.figlet_format("net-benchmark") + Style.RESET_ALL)
-        print(Fore.CYAN + "dns · http · ssl benchmarking suite" + Style.RESET_ALL)
-        print(
-            Fore.YELLOW
-            + "https://github.com/net-benchmark/net-benchmark"
-            + Style.RESET_ALL
-        )
-        print()
-
-
-def create_progress_bar(total: int, desc: str) -> Any:
-    return tqdm(
-        total=total, desc=info(desc), bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}"
-    )
-
-
-@cli.group(invoke_without_command=True)
-@click.pass_context
-def dns(ctx: click.Context) -> None:
-    """benchmark dns resolvers — doh, dot, dnssec supported."""
-    if ctx.invoked_subcommand is None:
-        click.echo(ctx.get_help())
+# ── DNS command group ─────────────────────────────────────────────────────────
+@click.group(name="dns")
+def dns() -> None:
+    """Benchmark DNS resolvers — DoH, DoT, DNSSEC supported."""
+    pass
 
 
 # =================== Benchmark command
@@ -1689,36 +1660,5 @@ settings:
     click.echo(summary_box(summary_lines))
 
 
-# ##################################### HTTP Benchmark ############################
-
-
-@cli.group()
-def http() -> None:
-    """benchmark http/https endpoints. (coming in 0.5.0)"""
-    pass
-
-
-@http.command()
-def bench() -> None:  # named bench to avoid clash with dns benchmark
-    """benchmark http/https targets for latency and availability."""
-    click.echo(info("http benchmark coming in net-benchmark 0.5.0"))
-    click.echo(info("follow progress: https://github.com/net-benchmark/net-benchmark"))
-
-
-# ##################################### SSL Check ############################
-
-
-@cli.group()
-def ssl_grp() -> None:  # named ssl_grp to avoid stdlib ssl conflict at module level
-    """check ssl certificate expiry and chain validity. (coming in 0.6.0)"""
-    pass
-
-
-cli.add_command(ssl_grp, name="ssl")
-
-
-@ssl_grp.command()
-def check() -> None:
-    """check ssl certificate expiry and chain validity."""
-    click.echo(info("ssl check coming in net-benchmark 0.6.0"))
-    click.echo(info("follow progress: https://github.com/net-benchmark/net-benchmark"))
+# alias for backward compatibility with tests and old scripts
+cli = dns

--- a/src/net_benchmark/dns_benchmark/tests/test_benchmark_cli.py
+++ b/src/net_benchmark/dns_benchmark/tests/test_benchmark_cli.py
@@ -12,12 +12,10 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from net_benchmark.dns_benchmark.cli import (
-    _resolve_protocol_and_doh_urls,
-    cli,
-    create_progress_bar,
-)
+from net_benchmark.cli import cli
 from net_benchmark.dns_benchmark.core import DNSQueryResult, QueryProtocol, QueryStatus
+from net_benchmark.utils.helpers import create_progress_bar
+from net_benchmark.utils.protocols import _resolve_protocol_and_doh_urls
 
 
 @pytest.fixture

--- a/src/net_benchmark/dns_benchmark/tests/test_list_commands.py
+++ b/src/net_benchmark/dns_benchmark/tests/test_list_commands.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from net_benchmark.dns_benchmark.cli import cli
+from net_benchmark.cli import cli
 
 
 def test_list_defaults():

--- a/src/net_benchmark/exporters/base.py
+++ b/src/net_benchmark/exporters/base.py
@@ -1,0 +1,226 @@
+"""Shared exporter base utilities."""
+
+from typing import Any, List, Tuple
+
+import matplotlib
+import matplotlib.pyplot as plt
+import pandas as pd
+from openpyxl import Workbook
+from openpyxl.drawing.image import Image as XLImage
+from openpyxl.styles import Font, PatternFill
+from openpyxl.utils.dataframe import dataframe_to_rows
+
+matplotlib.use("Agg")
+
+# ---------------------------------------------------------------------------
+# Colour constants reused across all three modules
+# ---------------------------------------------------------------------------
+
+FILL_HEADER = PatternFill(start_color="E0E0E0", end_color="E0E0E0", fill_type="solid")
+FILL_GREEN = PatternFill(start_color="C6EFCE", end_color="C6EFCE", fill_type="solid")
+FILL_AMBER = PatternFill(start_color="FFEB9C", end_color="FFEB9C", fill_type="solid")
+FILL_RED = PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")
+
+# Bar chart colour thresholds — callers pass their own boundary tuples when the
+# defaults don't apply (e.g. SSL uses days_remaining, not latency).
+# Default: green < 50 ms, amber < 100 ms, red >= 100 ms.
+DEFAULT_BAR_THRESHOLDS: Tuple[float, float] = (50.0, 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Excel helpers
+# ---------------------------------------------------------------------------
+
+
+def autosize_columns(ws: Any, max_width: int = 50) -> None:
+    """Set each column width to the longest cell value, capped at max_width."""
+    for column in ws.columns:
+        max_length = max(
+            (len(str(cell.value)) for cell in column if cell.value is not None),
+            default=10,
+        )
+        ws.column_dimensions[column[0].column_letter].width = min(
+            max_length + 2, max_width
+        )
+
+
+def add_simple_table_sheet(wb: Workbook, title: str, df: pd.DataFrame) -> None:
+    """Create a formatted table sheet from a DataFrame.
+
+    Replaces the four verbatim copies in dns_benchmark/exporters.py.
+    """
+    ws = wb.create_sheet(title)
+    for col_idx, header in enumerate(df.columns, 1):
+        cell = ws.cell(row=1, column=col_idx, value=header)
+        cell.font = Font(bold=True)
+        cell.fill = FILL_HEADER
+    for row_idx, row in enumerate(dataframe_to_rows(df, index=False, header=False), 2):
+        for col_idx, value in enumerate(row, 1):
+            ws.cell(row=row_idx, column=col_idx, value=value)
+    autosize_columns(ws)
+
+
+def add_coloured_table_sheet(
+    wb: Workbook,
+    title: str,
+    headers: List[str],
+    rows: List[List[Any]],
+    # row_fill_fn(row_values) → PatternFill — caller decides colour logic
+    row_fill_fn: Any,
+) -> None:
+    """Create a table sheet where each data row is coloured by a caller function.
+
+    Used for DNSSEC sheet (DNS), Security Headers sheet (HTTP),
+    and Expiry Timeline sheet (SSL) — all share the same green/amber/red pattern
+    but with different logic deciding which colour applies.
+    """
+    ws = wb.create_sheet(title)
+    for col_idx, header in enumerate(headers, 1):
+        cell = ws.cell(row=1, column=col_idx, value=header)
+        cell.font = Font(bold=True)
+        cell.fill = FILL_HEADER
+    for row_idx, row_values in enumerate(rows, 2):
+        fill = row_fill_fn(row_values)
+        for col_idx, value in enumerate(row_values, 1):
+            cell = ws.cell(row=row_idx, column=col_idx, value=value)
+            cell.fill = fill
+    autosize_columns(ws)
+
+
+def embed_charts_sheet(
+    wb: Workbook,
+    title: str,
+    chart_entries: List[Tuple[str, str, str]],  # (cell_anchor, heading, image_path)
+    sheet_title: str = "",
+) -> None:
+    """Embed pre-generated chart PNGs into a Charts sheet.
+
+    chart_entries: list of (anchor_cell, heading_cell, image_path)
+    e.g. [("A4", "A3", "/tmp/latency.png"), ("A24", "A23", "/tmp/success.png")]
+    """
+    ws = wb.create_sheet(title)
+    if sheet_title:
+        ws["A1"] = sheet_title
+        ws["A1"].font = Font(bold=True, size=14)
+    for heading_cell, anchor_cell, img_path in chart_entries:
+        if heading_cell:
+            ws[heading_cell].font = Font(bold=True, size=12)
+        img = XLImage(img_path)
+        img.width = 600
+        img.height = 360
+        ws.add_image(img, anchor_cell)
+
+
+# ---------------------------------------------------------------------------
+# Chart generation
+# ---------------------------------------------------------------------------
+
+
+def generate_bar_chart(
+    names: List[str],
+    values: List[float],
+    ylabel: str,
+    title: str,
+    output_path: str,
+    thresholds: Tuple[float, float] = DEFAULT_BAR_THRESHOLDS,
+    value_fmt: str = "{:.1f}",
+    figsize: Tuple[int, int] = (10, 6),
+    invert_colours: bool = False,
+) -> str:
+    """Generate a bar chart PNG and save to output_path. Returns output_path.
+
+    thresholds: (low, high) — values below low are green, below high amber, else red.
+    invert_colours: True for metrics where higher is better (e.g. success rate,
+                    days_remaining) — green is high, red is low.
+    value_fmt: format string for bar labels, e.g. "{:.1f}%" for percentages.
+    """
+    low, high = thresholds
+
+    def _colour(v: float) -> str:
+        if invert_colours:
+            return "#2ecc71" if v >= high else "#f39c12" if v >= low else "#e74c3c"
+        return "#2ecc71" if v < low else "#f39c12" if v < high else "#e74c3c"
+
+    colours = [_colour(v) for v in values]
+
+    fig, ax = plt.subplots(figsize=figsize)
+    if not names:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center", fontsize=14)
+        ax.axis("off")
+    else:
+        bars = ax.bar(range(len(names)), values, color=colours)
+        ax.set_xticks(range(len(names)))
+        ax.set_xticklabels(names, rotation=45, ha="right")
+        ax.set_ylabel(ylabel)
+        ax.set_title(title)
+        for bar in bars:
+            h = bar.get_height()
+            ax.annotate(
+                value_fmt.format(h),
+                xy=(bar.get_x() + bar.get_width() / 2, h),
+                xytext=(0, 3),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+            )
+        ax.grid(True, alpha=0.3, axis="y")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close()
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# PDF / HTML shared CSS
+# ---------------------------------------------------------------------------
+
+BASE_CSS = """
+    body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        margin: 0; padding: 20px; color: #333; line-height: 1.6;
+    }
+    .header {
+        text-align: center;
+        border-bottom: 3px solid #2c3e50;
+        padding-bottom: 20px;
+        margin-bottom: 30px;
+    }
+    .section { margin-bottom: 40px; }
+    table {
+        width: 100%; border-collapse: collapse;
+        margin: 20px 0; font-size: 0.9em;
+    }
+    th, td { padding: 10px 14px; text-align: left; border-bottom: 1px solid #ddd; }
+    th { background-color: #34495e; color: white; }
+    tr:nth-child(even) { background-color: #f8f9fa; }
+    .badge-ok      { color: #27ae60; font-weight: bold; }
+    .badge-warn    { color: #e67e22; font-weight: bold; }
+    .badge-crit    { color: #e74c3c; font-weight: bold; }
+    .badge-missing { color: #95a5a6; }
+    .chart { text-align: center; margin: 30px 0; }
+    .chart img {
+        max-width: 100%; height: auto;
+        border: 1px solid #ddd; border-radius: 5px;
+    }
+    .alert-box {
+        background: #ffeeba; border: 1px solid #ffc107;
+        border-radius: 4px; padding: 12px 16px; margin: 10px 0;
+    }
+"""
+
+
+def html_page(title: str, body: str) -> str:
+    """Wrap body HTML in a full page with shared CSS."""
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>{title}</title>
+  <style>{BASE_CSS}</style>
+</head>
+<body>
+{body}
+</body>
+</html>"""

--- a/src/net_benchmark/http_bench/analysis.py
+++ b/src/net_benchmark/http_bench/analysis.py
@@ -1,0 +1,455 @@
+"""Statistical analysis of HTTP benchmark results."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, cast
+
+import numpy as np
+import pandas as pd
+
+from net_benchmark.dns_benchmark.core import QueryStatus
+from net_benchmark.http_bench.core import HTTPProtocol, HTTPResult
+
+
+@dataclass
+class TargetStats:
+    """Statistics for a single HTTP target URL.
+
+    Field layout mirrors ResolverStats:
+      target              ← resolver_name  (identity)
+      method              ← (no DNS equivalent — HTTP-specific)
+      total_requests      ← total_queries
+      successful_requests ← successful_queries
+      success_rate        ← success_rate
+      min/max/avg/...     ← same latency stat fields, same formulas
+      http2_rate          ← dnssec_validation_rate  (protocol quality signal)
+    """
+
+    target: str
+    method: str
+    total_requests: int
+    successful_requests: int
+    success_rate: float
+    # latency — identical field names and formulas as ResolverStats
+    min_latency: float
+    max_latency: float
+    avg_latency: float
+    median_latency: float
+    std_latency: float
+    p95_latency: float
+    p99_latency: float
+    jitter: float = 0.0
+    consistency_score: float = 0.0
+    # HTTP-specific timing
+    avg_ttfb_ms: float = 0.0
+    p95_ttfb_ms: float = 0.0
+    # protocol
+    http2_rate: float = 0.0  # requests that negotiated HTTP/2
+    redirect_rate: float = 0.0  # requests with at least one redirect
+    # response
+    avg_response_size_bytes: float = 0.0
+    avg_dns_ms: float = 0.0
+    avg_tcp_ms: float = 0.0
+    avg_tls_ms: float = 0.0
+    avg_compressed_size_bytes: float = 0.0
+    avg_redirect_time_ms: float = 0.0
+    http2_downgrade_rate: float = 0.0
+    cache_control_present: int = 0
+    etag_present: int = 0
+    last_modified_present: int = 0
+    age_present: int = 0
+    # security signals — counts across all requests for this target
+    hsts_present: int = 0
+    csp_present: int = 0
+    cdn_fingerprint: Optional[str] = None  # most common CDN for this target
+    server_header: Optional[str] = None  # most common server header
+    cert_expiry_days_min: Optional[int] = None  # worst cert seen across requests
+    alt_svc: Optional[str] = None
+    ip_version: Optional[str] = None  # most common across requests
+
+
+class HTTPAnalyzer:
+    """Analyse HTTP benchmark results and compute statistics.
+
+    Mirrors BenchmarkAnalyzer structure exactly — same __init__, same
+    _create_dataframe pattern, same public method signatures.
+    """
+
+    def __init__(self, results: List[HTTPResult]) -> None:
+        self.results = results
+        self.df = self._create_dataframe()
+
+    def _create_dataframe(self) -> pd.DataFrame:
+        """Convert HTTPResult list to DataFrame.
+
+        Column mapping mirrors dns analysis.py _create_dataframe:
+          latency_ms   → total_ms
+          completed    → status == SUCCESS  (no DNSSEC_FAILED equivalent)
+          resolver_name → target
+          protocol.value → protocol
+        """
+        data = []
+        for r in self.results:
+            data.append(
+                {
+                    "target": r.target,
+                    "method": r.method,
+                    "total_ms": r.total_ms,
+                    "ttfb_ms": r.ttfb_ms,
+                    "dns_resolve_ms": r.dns_resolve_ms,
+                    "dns_resolver_ip": r.dns_resolver_ip,
+                    "tcp_connect_ms": r.tcp_connect_ms,
+                    "tls_handshake_ms": r.tls_handshake_ms,
+                    "status": r.status.value,
+                    "completed": r.status == QueryStatus.SUCCESS,
+                    "http_status_code": r.http_status_code,
+                    "protocol": r.protocol.value,
+                    "alpn_negotiated": r.alpn_negotiated or "",
+                    "http2": r.protocol == HTTPProtocol.HTTP2,
+                    "redirect_count": r.redirect_count,
+                    "response_size_bytes": r.response_size_bytes or 0,
+                    "compressed": r.compressed,
+                    "compressed_size_bytes": r.compressed_size_bytes,
+                    "redirect_timings": r.redirect_timings,
+                    "http2_downgraded": r.http2_downgraded,
+                    "hsts": r.security_headers.get("strict-transport-security")
+                    is not None,
+                    "csp": r.security_headers.get("content-security-policy")
+                    is not None,
+                    "cdn_fingerprint": r.cdn_fingerprint or "",
+                    "server_header": r.server_header or "",
+                    "cert_expiry_days": r.cert_expiry_days,
+                    "alt_svc": r.alt_svc or "",
+                    "ip_version": r.ip_version or "",
+                    "error_message": r.error_message or "",
+                    "attempt_number": r.attempt_number,
+                    "iteration": r.iteration,
+                    "query_id": r.query_id,
+                    "start_time": r.start_time,
+                    "cache_control": r.cache_control or "",
+                    "etag": r.etag or "",
+                    "last_modified": r.last_modified or "",
+                    "age": r.age or "",
+                    "assertion_results": r.assertion_results,
+                }
+            )
+        return pd.DataFrame(data)
+
+    def get_target_statistics(self) -> List[TargetStats]:
+        """Compute per-target statistics. Mirrors get_resolver_statistics."""
+        stats_list = []
+
+        for target in self.df["target"].unique():
+            td = self.df[self.df["target"] == target]
+            method = td["method"].iloc[0]
+
+            total = len(td)
+            successful = int(td["completed"].sum())
+            success_rate = (successful / total * 100) if total > 0 else 0.0
+
+            latencies = td[td["completed"]]["total_ms"]
+            ttfb_vals = td[td["completed"] & td["ttfb_ms"].notna()]["ttfb_ms"]
+
+            # Timing breakdown averages
+            dns_vals = td[td["completed"] & td["dns_resolve_ms"].notna()][
+                "dns_resolve_ms"
+            ]
+            tcp_vals = td[td["completed"] & td["tcp_connect_ms"].notna()][
+                "tcp_connect_ms"
+            ]
+            tls_vals = td[td["completed"] & td["tls_handshake_ms"].notna()][
+                "tls_handshake_ms"
+            ]
+
+            avg_dns = float(dns_vals.mean()) if len(dns_vals) > 0 else 0.0
+            avg_tcp = float(tcp_vals.mean()) if len(tcp_vals) > 0 else 0.0
+            avg_tls = float(tls_vals.mean()) if len(tls_vals) > 0 else 0.0
+
+            if len(latencies) > 0:
+                arr = latencies.values
+                min_l = float(latencies.min())
+                max_l = float(latencies.max())
+                avg_l = float(latencies.mean())
+                med_l = float(latencies.median())
+                std_l = float(latencies.std())
+                p95_l = float(latencies.quantile(0.95))
+                p99_l = float(latencies.quantile(0.99))
+
+                if len(arr) == 1:
+                    jitter = 0.0
+                    consistency = 100.0
+                else:
+                    jitter = float(np.std(np.diff(arr)))
+                    cv = std_l / avg_l if avg_l > 0 else 0.0
+                    consistency = max(0.0, 100.0 - cv * 100.0)
+            else:
+                min_l = max_l = avg_l = med_l = std_l = float("nan")
+                p95_l = p99_l = 0.0
+                jitter = 0.0
+                consistency = 0.0
+
+            avg_ttfb = float(ttfb_vals.mean()) if len(ttfb_vals) > 0 else 0.0
+            p95_ttfb = float(ttfb_vals.quantile(0.95)) if len(ttfb_vals) > 0 else 0.0
+
+            # protocol signals
+            http2_rate = (
+                float(td[td["completed"]]["http2"].mean() * 100)
+                if successful > 0
+                else 0.0
+            )
+            redirect_rate = float((td["redirect_count"] > 0).mean() * 100)
+
+            avg_size = (
+                float(td[td["completed"]]["response_size_bytes"].mean())
+                if successful > 0
+                else 0.0
+            )
+
+            # security signals
+            hsts_count = int(td["hsts"].sum())
+            csp_count = int(td["csp"].sum())
+
+            # Cache header presence (count non‑empty values among completed requests)
+            cache_control_count = td[
+                td["completed"] & (td["cache_control"] != "")
+            ].shape[0]
+            etag_count = td[td["completed"] & (td["etag"] != "")].shape[0]
+            last_modified_count = td[
+                td["completed"] & (td["last_modified"] != "")
+            ].shape[0]
+            age_count = td[td["completed"] & (td["age"] != "")].shape[0]
+
+            # Compressed size average
+            comp_vals = td[td["completed"] & td["compressed_size_bytes"].notna()][
+                "compressed_size_bytes"
+            ]
+            avg_comp = float(comp_vals.mean()) if len(comp_vals) > 0 else 0.0
+
+            # Average redirect time (flatten all hop timings)
+            redirect_times = []
+            for _, row in td[td["completed"]].iterrows():
+                for hop in row.get("redirect_timings", []):
+                    redirect_times.append(hop["duration_ms"])
+            avg_redirect = (
+                sum(redirect_times) / len(redirect_times) if redirect_times else 0.0
+            )
+
+            # HTTP/2 downgrade rate
+            downgrade_count = int(
+                td[(td["completed"]) & (td["http2_downgraded"] == True)].shape[0]
+            )
+            http2_downgrade_rate = (
+                (downgrade_count / successful * 100) if successful > 0 else 0.0
+            )
+
+            # most common CDN and server header (mode, ignoring empty strings)
+            cdn_vals = td[td["cdn_fingerprint"] != ""]["cdn_fingerprint"]
+            cdn = str(cdn_vals.mode().iloc[0]) if len(cdn_vals) > 0 else None
+
+            srv_vals = td[td["server_header"] != ""]["server_header"]
+            srv = str(srv_vals.mode().iloc[0]) if len(srv_vals) > 0 else None
+
+            # worst (minimum) cert expiry seen for this target
+            cert_days_series = td["cert_expiry_days"].dropna()
+            cert_min = (
+                int(cert_days_series.min()) if len(cert_days_series) > 0 else None
+            )
+            alt_svc_vals = td[td["alt_svc"] != ""]["alt_svc"]
+            alt_svc = (
+                str(alt_svc_vals.mode().iloc[0]) if len(alt_svc_vals) > 0 else None
+            )
+
+            ip_vals = td[td["ip_version"] != ""]["ip_version"]
+            ip_version = str(ip_vals.mode().iloc[0]) if len(ip_vals) > 0 else None
+
+            stats_list.append(
+                TargetStats(
+                    target=target,
+                    method=method,
+                    total_requests=total,
+                    successful_requests=successful,
+                    success_rate=success_rate,
+                    min_latency=min_l,
+                    max_latency=max_l,
+                    avg_latency=avg_l,
+                    median_latency=med_l,
+                    std_latency=std_l,
+                    p95_latency=p95_l,
+                    p99_latency=p99_l,
+                    jitter=jitter,
+                    consistency_score=consistency,
+                    avg_ttfb_ms=avg_ttfb,
+                    p95_ttfb_ms=p95_ttfb,
+                    http2_rate=http2_rate,
+                    redirect_rate=redirect_rate,
+                    avg_response_size_bytes=avg_size,
+                    avg_dns_ms=avg_dns,
+                    avg_tcp_ms=avg_tcp,
+                    avg_tls_ms=avg_tls,
+                    avg_compressed_size_bytes=avg_comp,
+                    avg_redirect_time_ms=avg_redirect,
+                    http2_downgrade_rate=http2_downgrade_rate,
+                    cache_control_present=cache_control_count,
+                    etag_present=etag_count,
+                    last_modified_present=last_modified_count,
+                    age_present=age_count,
+                    hsts_present=hsts_count,
+                    csp_present=csp_count,
+                    cdn_fingerprint=cdn,
+                    server_header=srv,
+                    cert_expiry_days_min=cert_min,
+                    alt_svc=alt_svc,
+                    ip_version=ip_version,
+                )
+            )
+
+        return stats_list
+
+    def get_overall_statistics(self) -> Dict[str, Any]:
+        """Overall benchmark statistics. Mirrors BenchmarkAnalyzer.get_overall_statistics."""
+        total = len(self.df)
+        successful = int(self.df["completed"].sum())
+        success_rate = (successful / total * 100) if total > 0 else 0.0
+
+        latencies = self.df[self.df["completed"]]["total_ms"]
+        ttfb_vals = self.df[self.df["completed"] & self.df["ttfb_ms"].notna()][
+            "ttfb_ms"
+        ]
+
+        avg_l = float(latencies.mean()) if len(latencies) > 0 else 0.0
+        med_l = float(latencies.median()) if len(latencies) > 0 else 0.0
+        avg_ttfb = float(ttfb_vals.mean()) if len(ttfb_vals) > 0 else 0.0
+
+        target_stats = self.get_target_statistics()
+        ranked = sorted(
+            [s for s in target_stats if s.successful_requests > 0],
+            key=lambda s: s.avg_latency,
+        )
+
+        http2_rate = (
+            float(self.df[self.df["completed"]]["http2"].mean() * 100)
+            if successful > 0
+            else 0.0
+        )
+        hsts_targets = sum(1 for s in target_stats if s.hsts_present > 0)
+        resolver_ip = self.results[0].dns_resolver_ip if self.results else None
+
+        assertion_pass_count = (
+            sum(
+                1
+                for r in self.results
+                if r.status == QueryStatus.SUCCESS and all(r.assertion_results.values())
+            )
+            if self.results
+            else 0
+        )
+        assertion_pass_rate = (assertion_pass_count / total * 100) if total > 0 else 0.0
+
+        return {
+            "total_requests": total,
+            "successful_requests": successful,
+            "overall_success_rate": success_rate,
+            "overall_avg_latency": avg_l,
+            "overall_median_latency": med_l,
+            "overall_avg_ttfb": avg_ttfb,
+            "fastest_target": ranked[0].target if ranked else "N/A",
+            "slowest_target": ranked[-1].target if ranked else "N/A",
+            "target_count": len(target_stats),
+            "http2_rate": http2_rate,
+            "hsts_coverage": (
+                (hsts_targets / len(target_stats) * 100) if target_stats else 0.0
+            ),
+            "dns_resolver_ip": resolver_ip,
+            "assertion_pass_rate": assertion_pass_rate,
+        }
+
+    def get_ttfb_statistics(self) -> List[Dict[str, Any]]:
+        """Per-target TTFB breakdown. Mirrors get_domain_statistics."""
+        result = []
+        for target in self.df["target"].unique():
+            td = self.df[self.df["target"] == target]
+            vals = td[td["completed"] & td["ttfb_ms"].notna()]["ttfb_ms"]
+            result.append(
+                {
+                    "target": target,
+                    "avg_ttfb_ms": float(vals.mean()) if len(vals) > 0 else 0.0,
+                    "median_ttfb_ms": float(vals.median()) if len(vals) > 0 else 0.0,
+                    "p95_ttfb_ms": float(vals.quantile(0.95)) if len(vals) > 0 else 0.0,
+                    "p99_ttfb_ms": float(vals.quantile(0.99)) if len(vals) > 0 else 0.0,
+                    "min_ttfb_ms": float(vals.min()) if len(vals) > 0 else 0.0,
+                    "max_ttfb_ms": float(vals.max()) if len(vals) > 0 else 0.0,
+                }
+            )
+        return result
+
+    def get_protocol_distribution(self) -> List[Dict[str, Any]]:
+        """HTTP/1.1 vs HTTP/2 breakdown. Mirrors get_protocol_statistics."""
+        result = []
+        for proto in self.df["protocol"].unique():
+            pd_ = self.df[self.df["protocol"] == proto]
+            total = len(pd_)
+            successful = int(pd_["completed"].sum())
+            latencies = pd_[pd_["completed"]]["total_ms"]
+            result.append(
+                {
+                    "protocol": proto,
+                    "total_requests": total,
+                    "successful_requests": successful,
+                    "success_rate": (successful / total * 100) if total > 0 else 0.0,
+                    "avg_latency": (
+                        float(latencies.mean()) if len(latencies) > 0 else 0.0
+                    ),
+                    "median_latency": (
+                        float(latencies.median()) if len(latencies) > 0 else 0.0
+                    ),
+                    "p95_latency": (
+                        float(latencies.quantile(0.95)) if len(latencies) > 0 else 0.0
+                    ),
+                }
+            )
+        return result
+
+    def get_security_summary(self) -> Dict[str, Any]:
+        """Aggregate security signal counts across all results.
+        Mirrors get_dnssec_statistics — the protocol-quality signal for HTTP.
+        """
+        total = len(self.df)
+        completed = self.df[self.df["completed"]]
+
+        # per-header presence counts
+        header_counts: Dict[str, int] = {}
+        for r in self.results:
+            for h, v in r.security_headers.items():
+                if v is not None:
+                    header_counts[h] = header_counts.get(h, 0) + 1
+
+        # CDN distribution
+        cdn_vals = self.df[self.df["cdn_fingerprint"] != ""]["cdn_fingerprint"]
+        cdn_dist = cdn_vals.value_counts().to_dict() if len(cdn_vals) > 0 else {}
+
+        # server header leak count (present = potential info disclosure)
+        server_leak_count = int((self.df["server_header"] != "").sum())
+
+        # cert expiry — worst across all results
+        cert_series = self.df["cert_expiry_days"].dropna()
+        cert_min = int(cert_series.min()) if len(cert_series) > 0 else None
+
+        return {
+            "security_header_counts": header_counts,
+            "cdn_distribution": cdn_dist,
+            "server_header_leak_count": server_leak_count,
+            "cert_expiry_days_min": cert_min,
+            "total_requests": total,
+            "completed_requests": int(completed["completed"].sum()),
+        }
+
+    def get_status_code_distribution(self) -> List[Dict[str, Any]]:
+        """HTTP status code breakdown. No DNS equivalent — HTTP-only."""
+        codes = self.df["http_status_code"].dropna().astype(int)
+        dist = codes.value_counts().rename_axis("status_code").reset_index(name="count")
+        dist["pct"] = (dist["count"] / len(self.df) * 100).round(2)
+        return cast(List[Dict[str, Any]], dist.to_dict(orient="records"))
+
+    def get_error_statistics(self) -> Dict[str, int]:
+        """Error message counts. Mirrors BenchmarkAnalyzer.get_error_statistics."""
+        errors = self.df[~self.df["completed"]]["error_message"]
+        return cast(Dict[str, int], errors.value_counts().to_dict())

--- a/src/net_benchmark/http_bench/cli.py
+++ b/src/net_benchmark/http_bench/cli.py
@@ -1,0 +1,1131 @@
+"""HTTP benchmarking CLI."""
+
+import asyncio
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import click
+from colorama import Fore, Style
+
+from net_benchmark.dns_benchmark.core import QueryStatus
+from net_benchmark.http_bench.analysis import HTTPAnalyzer
+from net_benchmark.http_bench.core import HTTPBenchmarkEngine, HTTPResult, TargetManager
+from net_benchmark.http_bench.exporters import (
+    HTTPCSVExporter,
+    HTTPExcelExporter,
+    HTTPExportBundle,
+    HTTPPDFExporter,
+)
+from net_benchmark.utils.helpers import create_progress_bar
+from net_benchmark.utils.messages import (
+    error,
+    info,
+    success,
+    summary_box,
+    warning,
+)
+
+
+# ── HTTP command group ────────────────────────────────────────────────────────
+@click.group(name="http")
+def http() -> None:
+    """Benchmark HTTP/HTTPS endpoints — latency, TTFB, security headers."""
+    pass
+
+
+# ── benchmark ─────────────────────────────────────────────────────────────────
+@http.command()
+@click.option(
+    "--targets",
+    "-t",
+    default=None,
+    help="Comma-separated URLs or path to a text file (one URL per line).",
+)
+@click.option(
+    "--use-defaults",
+    is_flag=True,
+    help="Use built-in default target URLs.",
+)
+@click.option(
+    "--method",
+    "-m",
+    default="GET",
+    show_default=True,
+    help="HTTP method (GET, POST, HEAD, …).",
+)
+@click.option(
+    "--headers",
+    default=None,
+    help='Extra request headers as "Key:Value,Key:Value".',
+)
+@click.option(
+    "--body",
+    default=None,
+    help="Request body string (e.g. JSON).",
+)
+@click.option(
+    "--body-file",
+    default=None,
+    help="Path to a file containing the request body.",
+)
+# ----------------
+@click.option(
+    "--auth",
+    default=None,
+    help="Authentication: 'basic:user:pass' or 'bearer:token'.",
+)
+@click.option(
+    "--cert",
+    default=None,
+    help="Path to client certificate file (PEM) for mTLS.",
+)
+@click.option(
+    "--cert-key",
+    default=None,
+    help="Path to client certificate private key file (if not combined with cert).",
+)
+@click.option(
+    "--cookie",
+    multiple=True,
+    default=None,
+    help="Cookie to include (repeatable, e.g. --cookie 'session=abc').",
+)
+@click.option(
+    "--user-agent",
+    default=None,
+    help="Custom User-Agent header.",
+)
+@click.option(
+    "--proxy",
+    default=None,
+    help="Proxy URL (e.g. http://127.0.0.1:8080).",
+)
+@click.option(
+    "--sni",
+    default=None,
+    help="Override TLS SNI hostname.",
+)
+@click.option(
+    "--local-address",
+    default=None,
+    help="Local IP address/interface to bind to.",
+)
+@click.option(
+    "--inject-request-id",
+    is_flag=True,
+    help="Add an X-Request-ID header to each request.",
+)
+@click.option(
+    "--assert",
+    "assertions_raw",
+    multiple=True,
+    default=None,
+    help="Assertion to check (repeatable). Format: 'type=value'. "
+    "Types: status, body_contains, header_exists, max_latency.",
+)
+@click.option(
+    "--output",
+    "-o",
+    default="./benchmark_results",
+    show_default=True,
+    help="Output directory for results.",
+)
+@click.option(
+    "--formats",
+    "-f",
+    default="csv,excel,pdf",
+    show_default=True,
+    help="Output formats (csv, excel, pdf).",
+)
+@click.option(
+    "--timeout", default=10.0, show_default=True, help="Request timeout in seconds."
+)
+@click.option(
+    "--max-concurrent",
+    default=50,
+    show_default=True,
+    help="Maximum concurrent requests.",
+)
+@click.option(
+    "--retries", default=2, show_default=True, help="Retries for failed requests."
+)
+@click.option(
+    "--iterations",
+    "-i",
+    default=1,
+    show_default=True,
+    help="Number of iterations per target.",
+)
+@click.option(
+    "--warmup", is_flag=True, help="Run full warmup requests before benchmark."
+)
+@click.option(
+    "--warmup-fast", is_flag=True, help="Run lightweight HEAD warmup per target."
+)
+@click.option("--no-http2", is_flag=True, help="Disable HTTP/2 (force HTTP/1.1).")
+@click.option(
+    "--no-verify-ssl", is_flag=True, help="Skip TLS certificate verification."
+)
+@click.option(
+    "--connect-timeout", type=float, default=None, help="Connection timeout (seconds)."
+)
+@click.option(
+    "--read-timeout", type=float, default=None, help="Read timeout (seconds)."
+)
+@click.option(
+    "--write-timeout", type=float, default=None, help="Write timeout (seconds)."
+)
+@click.option(
+    "--params", default=None, help='Query parameters as "key=value,key2=value2".'
+)
+@click.option(
+    "--include-charts", is_flag=True, help="Include charts in Excel and PDF exports."
+)
+@click.option("--json", "json_output", is_flag=True, help="Export results to JSON.")
+@click.option("--quiet", is_flag=True, help="Suppress progress output.")
+def benchmark(
+    targets: Optional[str],
+    use_defaults: bool,
+    method: str,
+    headers: Optional[str],
+    body: Optional[str],
+    body_file: Optional[str],
+    auth: Optional[str],
+    cert: Optional[str],
+    cert_key: Optional[str],
+    cookie: Optional[Tuple[str]],  # (multiple)
+    user_agent: Optional[str],
+    proxy: Optional[str],
+    sni: Optional[str],
+    local_address: Optional[str],
+    inject_request_id: bool,
+    assertions_raw: Optional[Tuple[str]],
+    output: str,
+    formats: str,
+    timeout: float,
+    max_concurrent: int,
+    retries: int,
+    iterations: int,
+    warmup: bool,
+    warmup_fast: bool,
+    no_http2: bool,
+    no_verify_ssl: bool,
+    connect_timeout: Optional[float],
+    read_timeout: Optional[float],
+    write_timeout: Optional[float],
+    params: Optional[str],
+    include_charts: bool,
+    json_output: bool,
+    quiet: bool,
+) -> None:
+    """Run HTTP benchmark test."""
+
+    # ── input validation ──────────────────────────────────────────────────────
+    if not use_defaults and not targets:
+        click.echo(error("Provide --targets or use --use-defaults."))
+        return
+
+    output_formats = [f.strip().lower() for f in formats.split(",")]
+    for fmt in output_formats:
+        if fmt not in ("csv", "excel", "pdf"):
+            click.echo(error(f"Invalid format '{fmt}'. Must be csv, excel, or pdf."))
+            return
+
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # ── parse targets ─────────────────────────────────────────────────────────
+    try:
+        if use_defaults:
+            target_list = TargetManager.get_default_targets()
+            if not quiet:
+                click.echo(success(f"Using default targets ({len(target_list)} URLs)"))
+        else:
+            target_list = TargetManager.parse_targets_input(targets).targets
+            if not quiet:
+                click.echo(success(f"Loaded {len(target_list)} targets"))
+    except FileNotFoundError as e:
+        click.echo(error(str(e)))
+        return
+    except Exception as e:
+        click.echo(error(f"Error loading targets: {e}"))
+        return
+
+    # ── parse extra headers ───────────────────────────────────────────────────
+    extra_headers: Dict[str, str] = {}
+    if headers:
+        for pair in headers.split(","):
+            if ":" in pair:
+                k, _, v = pair.partition(":")
+                extra_headers[k.strip()] = v.strip()
+
+    # ── parse query params ──────────────────────────────────────────────
+    query_params: Dict[str, str] = {}
+    if params:
+        for pair in params.split(","):
+            if "=" in pair:
+                k, _, v = pair.partition("=")
+                query_params[k.strip()] = v.strip()
+
+    # ── parse authentication ────────────────────────────────────────────────
+    auth_obj = None
+    if auth:
+        parts = auth.split(":", 1)
+        if parts[0].lower() == "basic":
+            if len(parts) != 2 or ":" not in parts[1]:
+                click.echo(error("Invalid basic auth format. Use 'basic:user:pass'."))
+                return
+            user, pwd = parts[1].split(":", 1)
+            from httpx import BasicAuth
+
+            auth_obj = BasicAuth(user, pwd)
+        elif parts[0].lower() == "bearer":
+            if len(parts) != 2:
+                click.echo(error("Invalid bearer auth format. Use 'bearer:token'."))
+                return
+            token = parts[1]
+            # Use a custom header injection? Actually httpx doesn't have BearerAuth, we can just set the header.
+            # Better: we'll pass a bearer auth object or set the header ourselves.
+            # We'll set extra_headers["Authorization"] = f"Bearer {token}"
+            extra_headers["Authorization"] = f"Bearer {token}"
+        else:
+            click.echo(
+                error(f"Unknown auth type '{parts[0]}'. Use 'basic' or 'bearer'.")
+            )
+            return
+    # For Basic auth, we pass auth_obj to the engine; for Bearer we already set the header.
+
+    # ── parse cookies ───────────────────────────────────────────────────────
+    cookies: Dict[str, str] = {}
+    if cookie:
+        for c in cookie:
+            if "=" not in c:
+                click.echo(error(f"Invalid cookie '{c}'. Use name=value."))
+                return
+            name, val = c.split("=", 1)
+            cookies[name.strip()] = val.strip()
+
+    # ── parse assertions ────────────────────────────────────────────────────
+    assertions: Dict[str, Any] = {}
+    if assertions_raw:
+        for a in assertions_raw:
+            if "=" not in a:
+                click.echo(error(f"Invalid assertion '{a}'. Use type=value."))
+                return
+            typ, val = a.split("=", 1)
+            typ = typ.strip().lower()
+            if typ == "status":
+                assertions["status_code"] = int(val)
+            elif typ == "body_contains":
+                assertions["body_contains"] = val
+            elif typ == "header_exists":
+                assertions["header_exists"] = val
+            elif typ == "max_latency":
+                try:
+                    assertions["max_latency"] = float(val)
+                except ValueError:
+                    click.echo(error("max_latency must be a number (ms)."))
+                    return
+            elif typ == "header_value":
+                # format: header_value:X-Cache=HIT
+                if "=" not in val:
+                    click.echo(error("header_value assertion requires header=value."))
+                    return
+                hdr, hval = val.split("=", 1)
+                assertions["header_value"] = {
+                    "header": hdr.strip(),
+                    "value": hval.strip(),
+                }
+            elif typ == "content_type":
+                assertions["content_type"] = val.strip()
+            elif typ == "response_size_min":
+                assertions["response_size_min"] = int(val)
+            elif typ == "response_size_max":
+                assertions["response_size_max"] = int(val)
+
+            else:
+                click.echo(error(f"Unknown assertion type '{typ}'."))
+                return
+
+    # ── set user-agent if provided ──────────────────────────────────────────
+    if user_agent:
+        extra_headers["User-Agent"] = user_agent
+
+    if body and body_file:
+        click.echo(error("Provide either --body or --body-file, not both."))
+        return
+
+    body_bytes: Optional[bytes] = None
+
+    if body_file:
+        try:
+            body_bytes = Path(body_file).read_bytes()
+        except Exception as e:
+            click.echo(error(f"Cannot read body file: {e}"))
+            return
+    elif body is not None:  # empty string is allowed
+        body_bytes = body.encode("utf-8")
+
+    # Auto‑set Content‑Type for JSON‑looking bodies if the user didn't provide one
+    if body_bytes and "content-type" not in {k.lower() for k in extra_headers}:
+        if (body_file and Path(body_file).suffix.lower() == ".json") or (
+            body_bytes
+            and (
+                body_bytes.lstrip().startswith(b"{")
+                or body_bytes.lstrip().startswith(b"[")
+            )
+        ):
+            extra_headers["Content-Type"] = "application/json"
+
+    total_requests = len(target_list) * iterations
+
+    if not quiet:
+        click.echo(info("Configuration:"))
+        click.echo(info(f"  Targets:      {len(target_list)}"))
+        click.echo(info(f"  Method:       {method.upper()}"))
+        click.echo(info(f"  Iterations:   {iterations}"))
+        click.echo(info(f"  Total reqs:   {total_requests}"))
+        click.echo(info(f"  HTTP/2:       {'disabled' if no_http2 else 'enabled'}"))
+        click.echo(info(f"  Verify SSL:   {'no' if no_verify_ssl else 'yes'}"))
+        if warmup_fast:
+            click.echo(info("  Warmup:       fast (HEAD per target)"))
+        elif warmup:
+            click.echo(info("  Warmup:       full"))
+
+    if not quiet:
+        click.echo(warning("Starting HTTP benchmark…"))
+
+    start_time = time.time()
+
+    try:
+        engine = HTTPBenchmarkEngine(
+            max_concurrent=max_concurrent,
+            timeout=timeout,
+            connect_timeout=connect_timeout,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            query_params=query_params,
+            max_retries=retries,
+            method=method.upper(),
+            headers=extra_headers,
+            http2=not no_http2,
+            verify_ssl=not no_verify_ssl,
+            auth=auth_obj,
+            cookies=cookies,
+            proxy=proxy,
+            sni_hostname=sni,
+            mtls_cert=cert,
+            mtls_key=cert_key,
+            local_address=local_address,
+            inject_request_id=inject_request_id,
+            assertions=assertions,
+            body=body_bytes,
+        )
+
+        progress_bar = None
+        if not quiet:
+            progress_bar = create_progress_bar(total_requests, "HTTP Requests")
+
+            def _progress_cb(completed: int, total: int) -> None:
+                try:
+                    if progress_bar:
+                        progress_bar.n = completed
+                        progress_bar.refresh()
+                except Exception:
+                    pass
+
+            engine.set_progress_callback(_progress_cb)
+
+        async def _run() -> List[HTTPResult]:
+            results = await engine.run_benchmark(
+                targets=target_list,
+                iterations=iterations,
+                warmup=warmup,
+                warmup_fast=warmup_fast,
+            )
+            await engine.close()
+            return results
+
+        results = asyncio.run(_run())
+
+        if progress_bar:
+            progress_bar.close()
+
+        duration = time.time() - start_time
+        if not quiet:
+            click.echo(success(f"Benchmark completed in {duration:.2f}s"))
+
+        # ── analysis ──────────────────────────────────────────────────────────
+        analyzer = HTTPAnalyzer(results)
+        overall = analyzer.get_overall_statistics()
+
+        if not quiet:
+            summary_lines = [
+                f"Total requests:   {overall['total_requests']}",
+                f"Successful:       {overall['successful_requests']} ({overall['overall_success_rate']:.2f}%)",
+                f"Avg latency:      {overall['overall_avg_latency']:.2f} ms",
+                f"Avg TTFB:         {overall['overall_avg_ttfb']:.2f} ms",
+                f"HTTP/2 rate:      {overall['http2_rate']:.1f}%",
+                f"HSTS coverage:    {overall['hsts_coverage']:.1f}%",
+                f"Fastest target:   {overall['fastest_target']}",
+                f"Slowest target:   {overall['slowest_target']}",
+            ]
+            click.echo(summary_box(summary_lines))
+
+        # ── export ────────────────────────────────────────────────────────────
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base = f"net_benchmark.http_benchmark_{timestamp}"
+
+        if not quiet:
+            click.echo(warning("Exporting results…"))
+
+        export_count = len(output_formats) + (1 if json_output else 0)
+        export_progress = (
+            create_progress_bar(export_count, "Exporting") if not quiet else None
+        )
+
+        try:
+            if "csv" in output_formats:
+                HTTPCSVExporter.export_raw_results(
+                    results, str(output_path / f"{base}_raw.csv")
+                )
+                HTTPCSVExporter.export_summary_statistics(
+                    analyzer, str(output_path / f"{base}_summary.csv")
+                )
+                HTTPCSVExporter.export_security_statistics(
+                    analyzer, str(output_path / f"{base}_security.csv")
+                )
+                HTTPCSVExporter.export_ttfb_statistics(
+                    analyzer, str(output_path / f"{base}_ttfb.csv")
+                )
+                HTTPCSVExporter.export_protocol_statistics(
+                    analyzer, str(output_path / f"{base}_protocols.csv")
+                )
+                if export_progress:
+                    export_progress.update(1)
+
+            if "excel" in output_formats:
+                HTTPExcelExporter.export_results(
+                    results,
+                    analyzer,
+                    str(output_path / f"{base}.xlsx"),
+                    include_charts=include_charts,
+                )
+                if export_progress:
+                    export_progress.update(1)
+
+            if "pdf" in output_formats:
+                try:
+                    HTTPPDFExporter.export_results(
+                        results,
+                        analyzer,
+                        str(output_path / f"{base}.pdf"),
+                        include_charts=include_charts,
+                    )
+                except Exception as e:
+                    click.echo(error(f"PDF export failed: {e}"))
+                finally:
+                    if export_progress:
+                        export_progress.update(1)
+
+            if json_output:
+                HTTPExportBundle.export_json(
+                    results,
+                    analyzer,
+                    str(output_path / f"{base}.json"),
+                )
+                if export_progress:
+                    export_progress.update(1)
+
+            if not quiet:
+                click.echo(success("All exports completed!"))
+                click.echo(info(f"Results saved to: {output_path}"))
+
+        finally:
+            if export_progress:
+                export_progress.close()
+
+    except click.UsageError:
+        raise
+    except KeyboardInterrupt:
+        click.echo(warning("\nBenchmark interrupted by user"))
+    except Exception as e:
+        click.echo(error(f"Benchmark error: {e}"))
+        raise
+
+
+# ── top ───────────────────────────────────────────────────────────────────────
+@http.command()
+@click.option("--targets", "-t", default=None, help="Targets inline or file.")
+@click.option("--use-defaults", is_flag=True, help="Use built-in default targets.")
+@click.option(
+    "--limit",
+    "-n",
+    default=5,
+    show_default=True,
+    help="Number of top targets to display.",
+)
+@click.option(
+    "--metric",
+    default="latency",
+    type=click.Choice(["latency", "ttfb", "success"], case_sensitive=False),
+    show_default=True,
+    help="Metric to rank by.",
+)
+@click.option("--quiet", is_flag=True, help="Suppress progress output.")
+def top(
+    targets: Optional[str],
+    use_defaults: bool,
+    limit: int,
+    metric: str,
+    quiet: bool,
+) -> None:
+    """Run a quick benchmark and show the top N targets by a metric.
+
+    Mirrors: dns top --limit N
+    """
+    if not use_defaults and not targets:
+        click.echo(error("Provide --targets or use --use-defaults."))
+        return
+
+    try:
+        target_list = (
+            TargetManager.get_default_targets()
+            if use_defaults
+            else TargetManager.parse_targets_input(targets).targets
+        )
+    except Exception as e:
+        click.echo(error(f"Error loading targets: {e}"))
+        return
+
+    if not quiet:
+        click.echo(info(f"Running quick benchmark across {len(target_list)} targets…"))
+
+    async def _run() -> List[HTTPResult]:
+        engine = HTTPBenchmarkEngine(max_concurrent=20, timeout=10.0, max_retries=1)
+        results = await engine.run_benchmark(
+            target_list, iterations=3, warmup_fast=True
+        )
+        await engine.close()
+        return results
+
+    results = asyncio.run(_run())
+    analyzer = HTTPAnalyzer(results)
+    stats = analyzer.get_target_statistics()
+
+    # Sort by chosen metric
+    metric_key = {
+        "latency": lambda s: s.avg_latency,
+        "ttfb": lambda s: s.avg_ttfb_ms,
+        "success": lambda s: -s.success_rate,  # negate so sort ascending = best first
+    }[metric.lower()]
+
+    ranked = sorted(
+        [s for s in stats if s.successful_requests > 0],
+        key=metric_key,
+    )[:limit]
+
+    click.echo(info(f"\nTop {limit} targets by {metric}:"))
+    click.echo(
+        f"  {'#':<4} {'Target':<45} {'Avg ms':>8} {'TTFB ms':>9} {'Success':>8} {'H/2':>6}"
+    )
+    click.echo("  " + "─" * 82)
+    for i, s in enumerate(ranked, 1):
+        label = s.target.replace("https://", "").replace("http://", "")[:44]
+        click.echo(
+            f"  {i:<4} {label:<45} {s.avg_latency:>8.1f} "
+            f"{s.avg_ttfb_ms:>9.1f} {s.success_rate:>7.1f}% "
+            f"{'✓' if s.http2_rate > 50 else '✗':>6}"
+        )
+
+
+# ── monitoring ───────────────────────────────────────────────────────────────────
+@http.command()
+@click.option("--targets", "-t", default=None, help="Targets inline or file.")
+@click.option("--use-defaults", is_flag=True, help="Use built-in default targets.")
+@click.option(
+    "--interval",
+    default=60,
+    show_default=True,
+    help="Seconds between checks.",
+)
+@click.option(
+    "--duration",
+    default=0,
+    show_default=True,
+    help="Total monitoring duration in seconds (0 = run until Ctrl-C).",
+)
+@click.option(
+    "--alert-latency",
+    default=0.0,
+    show_default=True,
+    help="Alert when avg latency exceeds N ms (0 = disabled).",
+)
+@click.option(
+    "--alert-failure-rate",
+    default=0.0,
+    show_default=True,
+    help="Alert when failure rate exceeds N% (0 = disabled).",
+)
+@click.option(
+    "--output",
+    "-o",
+    default="./monitoring_results",
+    show_default=True,
+    help="Directory to write per-interval JSON snapshots.",
+)
+def monitoring(
+    targets: Optional[str],
+    use_defaults: bool,
+    interval: int,
+    duration: int,
+    alert_latency: float,
+    alert_failure_rate: float,
+    output: str,
+) -> None:
+    """Continuously monitoring HTTP targets. Mirrors: dns monitoring.
+
+    Runs a benchmark every --interval seconds and prints a live summary.
+    Press Ctrl-C to stop.
+    """
+    if not use_defaults and not targets:
+        click.echo(error("Provide --targets or use --use-defaults."))
+        return
+
+    try:
+        target_list = (
+            TargetManager.get_default_targets()
+            if use_defaults
+            else TargetManager.parse_targets_input(targets).targets
+        )
+    except Exception as e:
+        click.echo(error(f"Error loading targets: {e}"))
+        return
+
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    click.echo(info(f"Monitoring {len(target_list)} targets every {interval}s"))
+    click.echo(info("Press Ctrl-C to stop.\n"))
+
+    start_wall = time.time()
+    iteration = 0
+
+    try:
+        while True:
+            iteration += 1
+            tick = time.time()
+
+            async def _run() -> List[HTTPResult]:
+                engine = HTTPBenchmarkEngine(
+                    max_concurrent=20, timeout=10.0, max_retries=1
+                )
+                res = await engine.run_benchmark(target_list, iterations=1)
+                await engine.close()
+                return res
+
+            results = asyncio.run(_run())
+            analyzer = HTTPAnalyzer(results)
+            overall = analyzer.get_overall_statistics()
+
+            now_str = datetime.now().strftime("%H:%M:%S")
+            status_colour = (
+                Fore.GREEN
+                if overall["overall_success_rate"] >= 95
+                else Fore.YELLOW if overall["overall_success_rate"] >= 80 else Fore.RED
+            )
+            click.echo(
+                f"[{now_str}] "
+                f"{status_colour}success={overall['overall_success_rate']:.1f}%{Style.RESET_ALL}  "
+                f"avg={overall['overall_avg_latency']:.1f}ms  "
+                f"ttfb={overall['overall_avg_ttfb']:.1f}ms  "
+                f"h2={overall['http2_rate']:.0f}%"
+            )
+
+            # ── alerts ────────────────────────────────────────────────────────
+            if alert_latency and overall["overall_avg_latency"] > alert_latency:
+                click.echo(
+                    warning(
+                        f"ALERT: avg latency {overall['overall_avg_latency']:.1f}ms "
+                        f"> threshold {alert_latency:.1f}ms"
+                    )
+                )
+            failure_rate = 100.0 - overall["overall_success_rate"]
+            if alert_failure_rate and failure_rate > alert_failure_rate:
+                click.echo(
+                    warning(
+                        f"ALERT: failure rate {failure_rate:.1f}% "
+                        f"> threshold {alert_failure_rate:.1f}%"
+                    )
+                )
+
+            # ── persist snapshot ──────────────────────────────────────────────
+            import json
+
+            snapshot_path = (
+                output_path
+                / f"http_monitor_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+            )
+            with open(snapshot_path, "w") as f:
+                json.dump(
+                    {"timestamp": datetime.now().isoformat(), "overall": overall},
+                    f,
+                    indent=2,
+                )
+
+            # ── duration check ────────────────────────────────────────────────
+            if duration and (time.time() - start_wall) >= duration:
+                click.echo(info("Monitoring duration reached. Stopping."))
+                break
+
+            # ── sleep until next interval ──────────────────────────────────────
+            elapsed = time.time() - tick
+            sleep_for = max(0.0, interval - elapsed)
+            time.sleep(sleep_for)
+
+    except KeyboardInterrupt:
+        click.echo(warning("\nMonitoring stopped by user."))
+
+
+# ── compare ───────────────────────────────────────────────────────────────────────
+@http.command()
+@click.argument("urls", nargs=-1, required=True)
+@click.option("--method", "-m", default="GET", show_default=True, help="HTTP method.")
+@click.option(
+    "--headers", default=None, help='Extra request headers as "Key:Value,Key:Value".'
+)
+@click.option("--body", default=None, help="Request body string (e.g. JSON).")
+@click.option(
+    "--body-file", default=None, help="Path to a file containing the request body."
+)
+@click.option(
+    "--auth", default=None, help="Authentication: 'basic:user:pass' or 'bearer:token'."
+)
+@click.option(
+    "--cert", default=None, help="Path to client certificate file (PEM) for mTLS."
+)
+@click.option(
+    "--cert-key", default=None, help="Path to client certificate private key file."
+)
+@click.option(
+    "--cookie", multiple=True, default=None, help="Cookie to include (repeatable)."
+)
+@click.option("--user-agent", default=None, help="Custom User-Agent header.")
+@click.option("--proxy", default=None, help="Proxy URL.")
+@click.option("--sni", default=None, help="Override TLS SNI hostname.")
+@click.option(
+    "--inject-request-id",
+    is_flag=True,
+    help="Add an X-Request-ID header to each request.",
+)
+@click.option(
+    "--iterations",
+    "-i",
+    default=3,
+    show_default=True,
+    help="Number of iterations per target.",
+)
+@click.option(
+    "--timeout", default=10.0, show_default=True, help="Request timeout in seconds."
+)
+@click.option(
+    "--max-concurrent",
+    default=20,
+    show_default=True,
+    help="Maximum concurrent requests.",
+)
+@click.option("--no-http2", is_flag=True, help="Disable HTTP/2.")
+@click.option(
+    "--no-verify-ssl", is_flag=True, help="Skip TLS certificate verification."
+)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Optional: save comparison to file (.csv, .json, .txt).",
+)
+@click.option("--quiet", is_flag=True, help="Suppress progress output.")
+@click.option("--show-details", is_flag=True, help="Show per-iteration breakdown.")
+def compare(
+    urls: Tuple[str],
+    method: str,
+    headers: Optional[str],
+    body: Optional[str],
+    body_file: Optional[str],
+    auth: Optional[str],
+    cert: Optional[str],
+    cert_key: Optional[str],
+    cookie: Optional[Tuple[str]],
+    user_agent: Optional[str],
+    proxy: Optional[str],
+    sni: Optional[str],
+    inject_request_id: bool,
+    iterations: int,
+    timeout: float,
+    max_concurrent: int,
+    no_http2: bool,
+    no_verify_ssl: bool,
+    output: Optional[str],
+    quiet: bool,
+    show_details: bool,
+) -> None:
+    """Compare specific HTTP targets side‑by‑side.
+
+    You can specify targets by full URL or just hostname (https:// is added if missing).
+
+    Examples:
+        net-benchmark http compare https://example.com https://httpbin.org/get
+        net-benchmark http compare api.example.com api2.example.com --iterations 5
+    """
+    # Normalize URLs – add scheme if missing
+    target_list = []
+    for u in urls:
+        u = u.strip()
+        if not u.startswith(("http://", "https://")):
+            u = "https://" + u
+        target_list.append(u)
+
+    if len(target_list) < 2:
+        click.echo(error("Need at least 2 targets to compare."))
+        return
+
+    # Parse extra headers
+    extra_headers: Dict[str, str] = {}
+    if headers:
+        for pair in headers.split(","):
+            if ":" in pair:
+                k, _, v = pair.partition(":")
+                extra_headers[k.strip()] = v.strip()
+
+    # Body / body-file conflict
+    if body and body_file:
+        click.echo(error("Provide either --body or --body-file, not both."))
+        return
+
+    body_bytes: Optional[bytes] = None
+    if body_file:
+        try:
+            body_bytes = Path(body_file).read_bytes()
+        except Exception as e:
+            click.echo(error(f"Cannot read body file: {e}"))
+            return
+    elif body is not None:
+        body_bytes = body.encode("utf-8")
+
+    if body_bytes and "content-type" not in {k.lower() for k in extra_headers}:
+        if (body_file and Path(body_file).suffix.lower() == ".json") or (
+            body_bytes.lstrip().startswith(b"{") or body_bytes.lstrip().startswith(b"[")
+        ):
+            extra_headers["Content-Type"] = "application/json"
+
+    # Auth
+    auth_obj = None
+    if auth:
+        parts = auth.split(":", 1)
+        if parts[0].lower() == "basic":
+            if len(parts) != 2 or ":" not in parts[1]:
+                click.echo(error("Invalid basic auth format. Use 'basic:user:pass'."))
+                return
+            user, pwd = parts[1].split(":", 1)
+            from httpx import BasicAuth
+
+            auth_obj = BasicAuth(user, pwd)
+        elif parts[0].lower() == "bearer":
+            if len(parts) != 2:
+                click.echo(error("Invalid bearer auth format. Use 'bearer:token'."))
+                return
+            extra_headers["Authorization"] = f"Bearer {parts[1]}"
+        else:
+            click.echo(error(f"Unknown auth type '{parts[0]}'."))
+            return
+
+    # Cookies
+    cookies: Dict[str, str] = {}
+    if cookie:
+        for c in cookie:
+            if "=" not in c:
+                click.echo(error(f"Invalid cookie '{c}'."))
+                return
+            name, val = c.split("=", 1)
+            cookies[name.strip()] = val.strip()
+
+    # User-Agent
+    if user_agent:
+        extra_headers["User-Agent"] = user_agent
+
+    if not quiet:
+        click.echo(info(f"🔬 Comparing {len(target_list)} targets…"))
+        click.echo(info(f"   Iterations: {iterations}"))
+
+    total_requests = len(target_list) * iterations
+
+    progress_bar = None
+    if not quiet:
+        progress_bar = create_progress_bar(total_requests, "Comparing")
+
+    try:
+        engine = HTTPBenchmarkEngine(
+            max_concurrent=max_concurrent,
+            timeout=timeout,
+            max_retries=2,
+            method=method.upper(),
+            headers=extra_headers,
+            http2=not no_http2,
+            verify_ssl=not no_verify_ssl,
+            auth=auth_obj,
+            cookies=cookies,
+            proxy=proxy,
+            sni_hostname=sni,
+            mtls_cert=cert,
+            mtls_key=cert_key,
+            inject_request_id=inject_request_id,
+            body=body_bytes,
+        )
+
+        if progress_bar:
+
+            def _progress_cb(completed: int, total: int) -> None:
+                try:
+                    if progress_bar:
+                        progress_bar.n = completed
+                        progress_bar.refresh()
+                except Exception:
+                    pass
+
+            engine.set_progress_callback(_progress_cb)
+
+        async def _run() -> List[HTTPResult]:
+            results = await engine.run_benchmark(
+                targets=target_list,
+                iterations=iterations,
+                warmup_fast=True,
+            )
+            await engine.close()
+            return results
+
+        results = asyncio.run(_run())
+
+        if progress_bar:
+            progress_bar.close()
+
+        analyzer = HTTPAnalyzer(results)
+        target_stats = analyzer.get_target_statistics()
+
+        # Sort by avg_latency (only successful)
+        valid = [s for s in target_stats if s.successful_requests > 0]
+        if not valid:
+            click.echo(error("No successful requests – nothing to compare."))
+            return
+
+        sorted_stats = sorted(valid, key=lambda s: s.avg_latency)
+
+        if not quiet:
+            click.echo(success("📊 Comparison Results:\n"))
+            # Table header
+            header = f"{'Target':<45} {'Avg (ms)':>8} {'TTFB (ms)':>9} {'Success':>8} {'H/2':>5}"
+            click.echo(Fore.CYAN + header + Style.RESET_ALL)
+            click.echo("-" * len(header))
+            for s in sorted_stats:
+                target_short = s.target.replace("https://", "").replace("http://", "")[
+                    :44
+                ]
+                h2 = "✓" if s.http2_rate > 50 else "✗"
+                click.echo(
+                    f"{target_short:<45} {s.avg_latency:>8.1f} {s.avg_ttfb_ms:>9.1f} {s.success_rate:>7.1f}% {h2:>5}"
+                )
+            click.echo()
+            fastest = sorted_stats[0]
+            most_reliable = max(valid, key=lambda s: s.success_rate)
+            click.echo(
+                Fore.GREEN
+                + "🏆 Fastest: "
+                + Style.RESET_ALL
+                + f"{fastest.target} ({fastest.avg_latency:.1f} ms)"
+            )
+            click.echo(
+                Fore.GREEN
+                + "🛡️  Most Reliable: "
+                + Style.RESET_ALL
+                + f"{most_reliable.target} ({most_reliable.success_rate:.1f}%)"
+            )
+
+            if show_details:
+                click.echo(success("\n📋 Per-Iteration Breakdown:\n"))
+                for target in target_list:
+                    target_results = [
+                        r
+                        for r in results
+                        if r.target == target and r.status == QueryStatus.SUCCESS
+                    ]
+                    if not target_results:
+                        continue
+                    click.echo(Fore.CYAN + f"{target}:" + Style.RESET_ALL)
+                    for i, r in enumerate(target_results, 1):
+                        click.echo(
+                            f"  Iter {i}: {r.total_ms:.1f} ms (TTFB {r.ttfb_ms:.1f} ms)"
+                        )
+
+        # Export if requested
+        if output:
+            output_path = Path(output)
+            ext = output_path.suffix.lower()
+            if ext == ".json":
+                data = {
+                    "timestamp": datetime.now().isoformat(),
+                    "iterations": iterations,
+                    "comparison": [
+                        {
+                            "target": s.target,
+                            "avg_latency_ms": s.avg_latency,
+                            "avg_ttfb_ms": s.avg_ttfb_ms,
+                            "success_rate": s.success_rate,
+                            "http2_rate": s.http2_rate,
+                            "successful_requests": s.successful_requests,
+                            "total_requests": s.total_requests,
+                        }
+                        for s in target_stats
+                    ],
+                }
+                with open(output_path, "w") as f:
+                    json.dump(data, f, indent=2)
+            elif ext == ".csv":
+                HTTPCSVExporter.export_summary_statistics(analyzer, str(output_path))
+            else:  # .txt
+                with open(output_path, "w") as f:
+                    f.write("HTTP Target Comparison\n")
+                    f.write(
+                        f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                    )
+                    f.write(
+                        f"{'Target':<45} {'Avg (ms)':>8} {'TTFB (ms)':>9} {'Success':>8} {'H/2':>5}\n"
+                    )
+                    f.write("-" * 80 + "\n")
+                    for s in sorted_stats:
+                        target_short = s.target.replace("https://", "").replace(
+                            "http://", ""
+                        )[:44]
+                        h2 = "✓" if s.http2_rate > 50 else "✗"
+                        f.write(
+                            f"{target_short:<45} {s.avg_latency:>8.1f} {s.avg_ttfb_ms:>9.1f} {s.success_rate:>7.1f}% {h2:>5}\n"
+                        )
+            if not quiet:
+                click.echo(success(f"Comparison saved to: {output_path}"))
+
+    except click.UsageError:
+        raise
+    except KeyboardInterrupt:
+        if progress_bar:
+            progress_bar.close()
+        click.echo(warning("\nComparison interrupted by user"))
+    except Exception as e:
+        if progress_bar:
+            progress_bar.close()
+        click.echo(error(f"Error during comparison: {e}"))
+        raise
+
+
+# alias for backward compatibility with tests and old scripts
+cli = http

--- a/src/net_benchmark/http_bench/core.py
+++ b/src/net_benchmark/http_bench/core.py
@@ -1,0 +1,1030 @@
+"""Core HTTP benchmarking functionality."""
+
+import asyncio
+import ipaddress
+import ssl
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from urllib.parse import urlparse
+
+import httpcore
+import httpx
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from httpcore._backends.auto import AutoBackend
+from httpcore._backends.base import (
+    SOCKET_OPTION,
+    AsyncNetworkBackend,
+    AsyncNetworkStream,
+)
+
+from net_benchmark.dns_benchmark.core import QueryStatus
+from net_benchmark.utils.messages import warning
+
+# ---------------------------------------------------------------------------
+# Timing wrappers — correct httpcore async ABC signatures
+# ---------------------------------------------------------------------------
+
+
+class TimingNetworkStream(AsyncNetworkStream):
+    """Wraps an AsyncNetworkStream to capture TCP-connect and TLS-handshake times.
+
+    The metrics dict is shared with TimingNetworkBackend so writes made inside
+    start_tls() are immediately visible there without any extra plumbing.
+    """
+
+    def __init__(self, stream: AsyncNetworkStream, metrics: Dict[str, Any]) -> None:
+        self._stream = stream
+        self._metrics = metrics  # shared reference — intentional
+
+    async def read(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        return await self._stream.read(max_bytes, timeout)
+
+    async def write(self, buffer: bytes, timeout: Optional[float] = None) -> None:
+        await self._stream.write(buffer, timeout)
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+    async def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> AsyncNetworkStream:
+        tls_start = time.perf_counter()
+        tls_stream = await self._stream.start_tls(ssl_context, server_hostname, timeout)
+        self._metrics["tls_handshake_ms"] = (time.perf_counter() - tls_start) * 1000
+        try:
+            ssl_obj = tls_stream.get_extra_info("ssl_object")
+            if ssl_obj is not None:
+                self._metrics["cert_der"] = ssl_obj.getpeercert(binary_form=True)
+        except Exception:
+            pass
+        # Wrap the TLS stream so further calls keep the same metrics reference
+        return TimingNetworkStream(tls_stream, self._metrics)
+
+    def get_extra_info(self, info: str) -> Any:
+        return self._stream.get_extra_info(info)
+
+
+class TimingNetworkBackend(AsyncNetworkBackend):
+    """Wraps AutoBackend to inject per-connection TCP and TLS timing.
+
+    One backend instance per origin so metrics are not clobbered across origins.
+    """
+
+    def __init__(self, local_address: Optional[str] = None) -> None:
+        self._backend = AutoBackend()
+        self.local_address = local_address
+        # Overwritten on every new connection — safe: asyncio is single-threaded.
+        self.metrics: Dict[str, Any] = {}
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: Optional[float] = None,
+        local_address: Optional[str] = None,
+        socket_options: Optional[Iterable[SOCKET_OPTION]] = None,
+    ) -> AsyncNetworkStream:
+
+        if local_address is None:
+            local_address = self.local_address
+
+        tcp_start = time.perf_counter()
+        stream = await self._backend.connect_tcp(
+            host,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+        self.metrics = {
+            "tcp_connect_ms": (time.perf_counter() - tcp_start) * 1000,
+            "tls_handshake_ms": None,
+            "cert_der": None,
+            "ip_version": None,
+        }
+        try:
+            server_addr = stream.get_extra_info("server_addr")
+            if isinstance(server_addr, tuple) and server_addr:
+                self.metrics["ip_version"] = (
+                    f"IPv{ipaddress.ip_address(server_addr[0]).version}"
+                )
+        except Exception:
+            pass
+        return TimingNetworkStream(stream, self.metrics)
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: Optional[float] = None,
+        socket_options: Optional[Iterable[SOCKET_OPTION]] = None,
+    ) -> AsyncNetworkStream:
+        return await self._backend.connect_unix_socket(
+            path, timeout=timeout, socket_options=socket_options
+        )
+
+    async def sleep(self, seconds: float) -> None:
+        await self._backend.sleep(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Transport — build httpcore pool directly to avoid overriding _init_pool
+# ---------------------------------------------------------------------------
+
+
+class MetricsCapturingTransport(httpx.AsyncHTTPTransport):
+    """AsyncHTTPTransport that captures per-connection timing and TLS metrics.
+
+    Rather than overriding the non-existent _init_pool hook, we build the
+    httpcore.AsyncConnectionPool ourselves and pass the custom TimingNetworkBackend
+    directly.
+    """
+
+    def __init__(
+        self,
+        verify: bool = True,
+        cert: Optional[Tuple[str, str]] = None,
+        http2: bool = False,
+        sni_hostname: Optional[str] = None,
+        mtls_cert: Optional[str] = None,
+        mtls_key: Optional[str] = None,
+        local_address: Optional[str] = None,
+    ) -> None:
+        # Build SSL context manually so we control mTLS and verification.
+        ssl_context = ssl.create_default_context()
+        if not verify:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+        if mtls_cert:
+            ssl_context.load_cert_chain(mtls_cert, mtls_key)
+        elif cert:
+            ssl_context.load_cert_chain(*cert)
+
+        self._timing_backend = TimingNetworkBackend(local_address=local_address)
+        self._sni_hostname = sni_hostname
+
+        # Inject our backend directly into httpcore's pool.  httpx's
+        # handle_async_request delegates to self._pool, so this is sufficient.
+        self._pool = httpcore.AsyncConnectionPool(
+            ssl_context=ssl_context,
+            http2=http2,
+            network_backend=self._timing_backend,
+        )
+
+    def get_connection_metrics(self) -> Dict[str, Any]:
+        """Return a snapshot of metrics from the most recently established connection."""
+        return dict(self._timing_backend.metrics)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_cert_der(
+    cert_der: bytes,
+) -> Tuple[Optional[int], Optional[str], Optional[str], List[str], bool]:
+    """Parse DER cert bytes with the cryptography library.
+
+    Returns (days_remaining, subject_cn, issuer_cn, sans, wildcard).
+    Uses cryptography (explicit dep) not ssl.getpeercert() dict, so all
+    fields are available consistently across Python versions.
+    """
+    try:
+        cert = x509.load_der_x509_certificate(cert_der)
+        # subject CN
+        try:
+            raw_cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+            cn: Optional[str] = (
+                raw_cn.decode("utf-8") if isinstance(raw_cn, bytes) else raw_cn
+            )
+        except IndexError:
+            cn = None
+        # issuer CN
+        try:
+            raw_issuer = cert.issuer.get_attributes_for_oid(NameOID.COMMON_NAME)[
+                0
+            ].value
+            issuer_cn: Optional[str] = (
+                raw_issuer.decode("utf-8")
+                if isinstance(raw_issuer, bytes)
+                else raw_issuer
+            )
+        except IndexError:
+            issuer_cn = None
+        # SANs
+        try:
+            san_ext = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            )
+            sans: List[str] = san_ext.value.get_values_for_type(x509.DNSName)
+        except Exception:
+            sans = []
+        wildcard = any(s.startswith("*.") for s in sans)
+        # expiry
+        try:
+            expiry = cert.not_valid_after_utc
+        except AttributeError:
+            expiry = cert.not_valid_after.replace(tzinfo=timezone.utc)
+        days = (expiry - datetime.now(tz=timezone.utc)).days
+        return days, cn, issuer_cn, sans, wildcard
+    except Exception:
+        return None, None, None, [], False
+
+
+# ---------------------------------------------------------------------------
+# Protocol enum
+# ---------------------------------------------------------------------------
+
+
+class HTTPProtocol(str, Enum):
+    """Negotiated application protocol — captured from the live connection."""
+
+    HTTP1 = "HTTP/1.1"
+    HTTP2 = "HTTP/2"
+    UNKNOWN = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+# Security headers audited on every HTTPS response.
+# Stored as Optional[str] — None means header absent, value means present.
+SECURITY_HEADERS = [
+    "strict-transport-security",
+    "content-security-policy",
+    "x-frame-options",
+    "x-content-type-options",
+    "referrer-policy",
+    "permissions-policy",
+]
+
+# Response headers that reveal CDN identity.
+CDN_HEADER_MAP: Dict[str, str] = {
+    "cf-ray": "Cloudflare",
+    "x-amz-cf-id": "CloudFront",
+    "fastly-restarts": "Fastly",
+    "x-served-by": "Fastly",
+    "x-azure-ref": "Azure CDN",
+    "x-cdn": "CDN",
+}
+
+# Headers requiring value inspection
+CDN_VALUE_PATTERNS: Dict[str, Dict[str, str]] = {
+    "server": {
+        "gws": "Google",
+        "googfe": "Google",
+        "cloudflare": "Cloudflare",
+        "akamai": "Akamai",
+        "nginx": "Nginx",
+        "AmazonS3": "CloudFront",
+        "ECS": "Akamai",
+        "ECAcc": "Akamai",
+    },
+    "via": {
+        "cloudflare": "Cloudflare",
+        "varnish": "Fastly/Varnish",
+        "akamai": "Akamai",
+        "google": "Google",
+    },
+    "x-cache": {
+        "cloudfront": "CloudFront",
+        "fastly": "Fastly",
+    },
+}
+
+
+@dataclass
+class HTTPResult:
+    """Result of a single HTTP request"""
+
+    # --- identity ---
+    target: str  # full URL
+    method: str  # HTTP verb
+    start_time: float
+    end_time: float
+    total_ms: float  # wall-clock latency — primary metric
+    status: QueryStatus
+    iteration: int = 1  # 0 = warmup
+    attempt_number: int = 1
+    query_id: str = field(default_factory=lambda: uuid.uuid4().hex[:8])
+    # --- HTTP response ---
+    http_status_code: Optional[int] = None
+    error_message: Optional[str] = None
+    redirect_count: int = 0
+    final_url: str = ""  # URL after following redirects
+    # --- timing breakdown (best-effort; None if not measurable) ---
+    ttfb_ms: Optional[float] = None  # time to first byte
+    ttlb_ms: Optional[float] = None  # time to last byte
+    # --- protocol ---
+    protocol: HTTPProtocol = HTTPProtocol.UNKNOWN
+    alpn_negotiated: Optional[str] = None  # "h2", "http/1.1", None for plain
+    # --- response metadata ---
+    response_size_bytes: Optional[int] = None
+    compressed: bool = False
+    content_encoding: Optional[str] = None
+    content_type: Optional[str] = None
+    # --- security signals (0.5.0 spike) ---
+    security_headers: Dict[str, Optional[str]] = field(default_factory=dict)
+    cdn_fingerprint: Optional[str] = None  # detected CDN name
+    server_header: Optional[str] = None  # server software/version leak
+    cert_expiry_days: Optional[int] = None  # from inline TLS cert capture
+    cert_cn: Optional[str] = None
+    alt_svc: Optional[str] = None
+    ip_version: Optional[str] = None  # "IPv4" or "IPv6"
+    cert_issuer_cn: Optional[str] = None
+    cert_sans: List[str] = field(default_factory=list)
+    cert_wildcard: bool = False
+    downgrade_detected: bool = False
+    redirect_urls: List[str] = field(default_factory=list)  # full hop list
+    tls_handshake_ms: Optional[float] = None
+    tcp_connect_ms: Optional[float] = None
+    dns_resolve_ms: Optional[float] = None
+    dns_resolver_ip: Optional[str] = None
+    compressed_size_bytes: Optional[int] = None
+    http2_expected: bool = False
+    http2_downgraded: bool = False
+    redirect_timings: List[Dict[str, Any]] = field(default_factory=list)
+    query_params: Dict[str, str] = field(default_factory=dict)
+    # cache headers
+    cache_control: Optional[str] = None
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+    age: Optional[str] = None
+    # auth / request tracking
+    request_id: Optional[str] = None
+    # assertions
+    assertion_results: Dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["status"] = self.status.value
+        d["protocol"] = self.protocol.value
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Target manager  (mirrors ResolverManager + DomainManager combined)
+# ---------------------------------------------------------------------------
+
+
+class TargetManager:
+    """Parse and validate HTTP target URLs."""
+
+    DEFAULT_TARGETS: List[str] = [
+        "https://www.cloudflare.com",
+        "https://www.google.com",
+        "https://www.github.com",
+        "https://www.wikipedia.org",
+        "https://www.apple.com",
+    ]
+
+    def __init__(self, targets: List[str]) -> None:
+        self._targets = targets
+
+    @property
+    def targets(self) -> List[str]:
+        return self._targets
+
+    @classmethod
+    def get_default_targets(cls) -> List[str]:
+        return cls.DEFAULT_TARGETS
+
+    @classmethod
+    def parse_targets_input(cls, input_value: Optional[str]) -> "TargetManager":
+        if not input_value:
+            raise ValueError("Target input cannot be empty")
+
+        input_value = input_value.strip()
+
+        # Explicit URL with scheme → definitely not a file
+        if input_value.startswith(("http://", "https://")):
+            if "," in input_value:
+                return cls(cls._parse_inline(input_value))
+            return cls([input_value])
+
+        # Heuristic: if it contains a path separator or a common text‑file extension,
+        # treat it as a file path.  Otherwise it's probably an inline URL.
+        likely_file = (
+            "/" in input_value
+            or "\\" in input_value
+            or Path(input_value).suffix
+            in (".txt", ".csv", ".list", ".conf", ".yaml", ".yml")
+        )
+
+        if likely_file:
+            path = Path(input_value)
+            if not path.exists() or not path.is_file():
+                raise FileNotFoundError(f"Target file not found: {input_value}")
+            return cls(cls._load_from_file(str(path)))
+
+        # Inline list or single URL (could be a bare domain)
+        if "," in input_value:
+            return cls(cls._parse_inline(input_value))
+        return cls([input_value])
+
+    @staticmethod
+    def _load_from_file(file_path: str) -> List[str]:
+        with open(file_path) as f:
+            return [
+                line.strip() for line in f if line.strip() and not line.startswith("#")
+            ]
+
+    @staticmethod
+    def _parse_inline(targets_str: str) -> List[str]:
+        seen: Set[str] = set()
+        result = []
+        for part in targets_str.split(","):
+            url = part.strip()
+            if url and url not in seen:
+                seen.add(url)
+                result.append(url)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# HTTP benchmark engine  (mirrors DNSQueryEngine)
+# ---------------------------------------------------------------------------
+
+
+class HTTPBenchmarkEngine:
+    def __init__(
+        self,
+        max_concurrent: int = 50,
+        timeout: float = 10.0,
+        connect_timeout: Optional[float] = None,
+        read_timeout: Optional[float] = None,
+        write_timeout: Optional[float] = None,
+        max_retries: int = 2,
+        retry_backoff_multiplier: float = 0.1,
+        retry_backoff_base: float = 2.0,
+        method: str = "GET",
+        headers: Optional[Dict[str, str]] = None,
+        follow_redirects: bool = True,
+        verify_ssl: bool = True,
+        http2: bool = True,
+        auth: Optional[Any] = None,
+        cookies: Optional[Dict[str, str]] = None,
+        proxy: Optional[str] = None,
+        sni_hostname: Optional[str] = None,
+        mtls_cert: Optional[str] = None,
+        mtls_key: Optional[str] = None,
+        inject_request_id: bool = False,
+        assertions: Optional[Dict[str, Any]] = None,
+        query_params: Optional[Dict[str, str]] = None,
+        body: Optional[bytes] = None,
+        local_address: Optional[str] = None,
+    ) -> None:
+        self.max_concurrent = max_concurrent
+        self.max_retries = max_retries
+        self.retry_backoff_multiplier = retry_backoff_multiplier
+        self.retry_backoff_base = retry_backoff_base
+        self.method = method.upper()
+        self.extra_headers = headers or {}
+        self.follow_redirects = follow_redirects
+        self.verify_ssl = verify_ssl
+        self.http2 = http2
+        self.auth = auth
+        self.cookies = cookies or {}
+        self.proxy = proxy
+        self.sni_hostname = sni_hostname
+        self.mtls_cert = mtls_cert
+        self.mtls_key = mtls_key
+        self.inject_request_id = inject_request_id
+        self.assertions = assertions or {}
+        self.body = body
+        self.local_address = local_address
+        self.semaphore: Optional[asyncio.Semaphore] = None
+        self._lock: Optional[asyncio.Lock] = None
+        self.progress_callback: Optional[Callable[[int, int], None]] = None
+        self.query_counter = 0
+        self.total_queries = 0
+        self.failed_targets: Dict[str, int] = defaultdict(int)
+        self._clients: Dict[str, httpx.AsyncClient] = {}
+        self._transports: Dict[str, MetricsCapturingTransport] = {}
+        self._dns_cache: Dict[str, Tuple[float, str]] = {}
+        self.dns_resolver_ip = self._detect_dns_resolver()
+
+        # Build timeout object — may be a plain float or an httpx.Timeout
+        if connect_timeout or read_timeout or write_timeout:
+            self._timeout: Union[float, httpx.Timeout] = httpx.Timeout(
+                connect=connect_timeout or timeout,
+                read=read_timeout or timeout,
+                write=write_timeout or timeout,
+                pool=connect_timeout or timeout,
+            )
+        else:
+            self._timeout = timeout
+
+        self.query_params = query_params or {}
+
+    def set_progress_callback(self, callback: Callable[[int, int], None]) -> None:
+        self.progress_callback = callback
+
+    async def _ensure_async_primitives(self) -> None:
+        if self.semaphore is None:
+            self.semaphore = asyncio.Semaphore(self.max_concurrent)
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+
+    async def _update_progress(self) -> None:
+        await self._ensure_async_primitives()
+        assert self._lock is not None
+        async with self._lock:
+            self.query_counter += 1
+            if self.progress_callback:
+                self.progress_callback(self.query_counter, self.total_queries)
+
+    def _origin(self, url: str) -> str:
+        """Extract scheme+host+port as pool key."""
+        p = urlparse(url)
+        return f"{p.scheme}://{p.netloc}"
+
+    def _get_transport(self, url: str) -> MetricsCapturingTransport:
+        origin = self._origin(url)
+        if origin not in self._transports:
+            cert: Optional[Tuple[str, str]] = None
+            if self.mtls_cert and self.mtls_key:
+                cert = (self.mtls_cert, self.mtls_key)
+            self._transports[origin] = MetricsCapturingTransport(
+                verify=self.verify_ssl,
+                cert=cert,
+                http2=self.http2,
+                sni_hostname=self.sni_hostname,
+                mtls_cert=self.mtls_cert,
+                mtls_key=self.mtls_key,
+                local_address=self.local_address,
+            )
+        return self._transports[origin]
+
+    async def _get_client(
+        self, url: str
+    ) -> Tuple[httpx.AsyncClient, MetricsCapturingTransport]:
+        """Return or create a shared (AsyncClient, transport) pair for this origin."""
+        origin = self._origin(url)
+
+        if origin not in self._clients:
+            transport = self._get_transport(url)
+            client_kwargs: Dict[str, Any] = dict(
+                transport=transport,
+                http2=self.http2,
+                verify=self.verify_ssl,
+                follow_redirects=self.follow_redirects,
+                timeout=httpx.Timeout(self._timeout),
+                headers=self.extra_headers,
+                cookies=self.cookies or None,
+            )
+            if self.auth:
+                client_kwargs["auth"] = self.auth
+            if self.proxy:
+                client_kwargs["proxy"] = self.proxy
+            self._clients[origin] = httpx.AsyncClient(**client_kwargs)
+
+        transport = self._transports[origin]
+        return self._clients[origin], transport
+
+    async def close(self) -> None:
+        """Close all pooled clients. Must be awaited after run_benchmark."""
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()
+        self._transports.clear()
+
+    def get_failed_targets(self) -> Dict[str, int]:
+        return dict(self.failed_targets)
+
+    def _run_assertions(self, response: httpx.Response, body: bytes) -> Dict[str, bool]:
+        results: Dict[str, bool] = {}
+        for name, config in self.assertions.items():
+            if name == "status_code":
+                results[name] = response.status_code == config
+            elif name == "body_contains":
+                results[name] = config in body.decode("utf-8", errors="ignore")
+            elif name == "header_exists":
+                results[name] = config in response.headers
+            elif name == "header_value":
+                header = config["header"]
+                value = config["value"]
+                results[name] = response.headers.get(header) == value
+            elif name == "content_type":
+                ct = response.headers.get("content-type", "")
+                results[name] = config in ct
+            elif name == "response_size_min":
+                results[name] = len(body) >= config
+            elif name == "response_size_max":
+                results[name] = len(body) <= config
+
+        return results
+
+    async def _resolve_host(self, host: str) -> Tuple[float, Optional[str]]:
+        """Resolve *host* (using the event loop) and return (ms, error_str)."""
+        start = time.perf_counter()
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.getaddrinfo(host, None)
+            elapsed = (time.perf_counter() - start) * 1000
+            return elapsed, None
+        except Exception as e:
+            elapsed = (time.perf_counter() - start) * 1000
+            return elapsed, str(e)
+
+    @staticmethod
+    def _detect_dns_resolver() -> Optional[str]:
+        """Return the primary system DNS resolver IP, or None."""
+        try:
+            import dns.resolver
+
+            resolvers = dns.resolver.Resolver().nameservers
+            if resolvers:
+                return str(resolvers[0])
+        except Exception:
+            pass
+        return None
+
+    # ------------------------------------------------------------------
+    # Security signal extraction helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_security_headers(
+        headers: httpx.Headers,
+    ) -> Dict[str, Optional[str]]:
+        return {h: headers.get(h) for h in SECURITY_HEADERS}
+
+    @staticmethod
+    def _detect_cdn(headers: httpx.Headers) -> Optional[str]:
+        for header, cdn_name in CDN_HEADER_MAP.items():
+            if header in headers:
+                return cdn_name
+        for header, patterns in CDN_VALUE_PATTERNS.items():
+            value = headers.get(header, "").lower()
+            if not value:
+                continue
+            for pattern, cdn_name in patterns.items():
+                if pattern.lower() in value:
+                    return cdn_name
+        return None
+
+    @staticmethod
+    def _detect_protocol(
+        response: httpx.Response,
+    ) -> Tuple[HTTPProtocol, Optional[str]]:
+        http_ver = getattr(response, "http_version", None)
+        if http_ver == "HTTP/2":
+            return HTTPProtocol.HTTP2, "h2"
+        elif http_ver == "HTTP/1.1":
+            return HTTPProtocol.HTTP1, "http/1.1"
+        return HTTPProtocol.UNKNOWN, None
+
+    # ------------------------------------------------------------------
+    # Single request
+    # ------------------------------------------------------------------
+
+    async def request_single(
+        self,
+        target: str,
+        iteration: int = 1,
+    ) -> HTTPResult:
+        """Execute a single HTTP request with retry logic."""
+        await self._ensure_async_primitives()
+        assert self.semaphore is not None
+
+        start_time = time.time()
+        client, transport = await self._get_client(target)
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                async with self.semaphore:
+                    start_time = time.perf_counter()
+
+                    # DNS resolution (timed)
+                    parsed = urlparse(target)
+                    hostname = parsed.hostname
+                    dns_ms = 0.0
+                    dns_error = None
+                    if hostname:
+                        if hostname not in self._dns_cache:
+                            dns_ms, dns_error = await self._resolve_host(hostname)
+                            if dns_error is None:
+                                self._dns_cache[hostname] = (dns_ms, "ok")
+                        else:
+                            dns_ms = 0.0
+
+                    # Append query parameters if any
+                    if self.query_params:
+                        qs = "&".join(f"{k}={v}" for k, v in self.query_params.items())
+                        target = target + ("&" if "?" in target else "?") + qs
+
+                    ttfb_ms: Optional[float] = None
+
+                    req_headers = dict(self.extra_headers)
+                    request_id: Optional[str] = None
+                    if self.inject_request_id:
+                        request_id = uuid.uuid4().hex[:8]
+                        req_headers["X-Request-ID"] = request_id
+
+                    async with client.stream(
+                        method=self.method,
+                        url=target,
+                        headers=req_headers,
+                        content=self.body,
+                    ) as response:
+                        headers_received = time.perf_counter()
+                        ttfb_ms = (headers_received - start_time) * 1000
+                        body = await response.aread()
+                        assertion_results = self._run_assertions(response, body)
+
+                    end_time = time.perf_counter()
+                    total_ms = (end_time - start_time) * 1000
+
+                    # Check max_latency assertion if defined
+                    if "max_latency" in self.assertions:
+                        assertion_results["max_latency"] = (
+                            total_ms <= self.assertions["max_latency"]
+                        )
+
+                    protocol, alpn = self._detect_protocol(response)
+
+                    content_encoding = response.headers.get("content-encoding")
+                    content_type = response.headers.get("content-type")
+                    compressed = content_encoding in ("gzip", "br", "zstd", "deflate")
+                    response_size = len(body)
+
+                    sec_headers = self._extract_security_headers(response.headers)
+                    cdn = self._detect_cdn(response.headers)
+                    alt_svc = response.headers.get("alt-svc")
+                    server = response.headers.get("server")
+
+                    redirect_count = len(response.history)
+                    final_url = str(response.url)
+
+                    # Walk history to get full hop list and detect downgrades
+                    redirect_urls = [str(r.url) for r in response.history]
+                    downgrade_detected = target.startswith("https://") and any(
+                        str(r.url).startswith("http://") for r in response.history
+                    )
+
+                    # Compressed size from Content-Length header
+                    cl = response.headers.get("content-length")
+                    compressed_size = int(cl) if cl else None
+
+                    # Redirect per-hop timings
+                    redirect_timings = []
+                    for prev_resp in response.history:
+                        redirect_timings.append(
+                            {
+                                "url": str(prev_resp.url),
+                                "status_code": prev_resp.status_code,
+                                "duration_ms": prev_resp.elapsed.total_seconds() * 1000,
+                            }
+                        )
+
+                    # HTTP/2 downgrade detection
+                    http2_expected = self.http2
+                    http2_downgraded = http2_expected and protocol != HTTPProtocol.HTTP2
+
+                    # Cache headers
+                    cache_control = response.headers.get("cache-control")
+                    etag = response.headers.get("etag")
+                    last_modified = response.headers.get("last-modified")
+                    age = response.headers.get("age")
+
+                    if response.is_success or response.is_redirect:
+                        status = QueryStatus.SUCCESS
+                    else:
+                        status = QueryStatus.UNKNOWN_ERROR
+
+                    result = HTTPResult(
+                        target=target,
+                        method=self.method,
+                        start_time=start_time,
+                        end_time=end_time,
+                        total_ms=total_ms,
+                        status=status,
+                        iteration=iteration,
+                        attempt_number=attempt + 1,
+                        http_status_code=response.status_code,
+                        redirect_count=redirect_count,
+                        final_url=final_url,
+                        redirect_urls=redirect_urls,
+                        downgrade_detected=downgrade_detected,
+                        ttfb_ms=ttfb_ms,
+                        ttlb_ms=total_ms,
+                        protocol=protocol,
+                        alpn_negotiated=alpn,
+                        response_size_bytes=response_size,
+                        compressed=compressed,
+                        content_encoding=content_encoding,
+                        content_type=content_type,
+                        security_headers=sec_headers,
+                        cdn_fingerprint=cdn,
+                        server_header=server,
+                        alt_svc=alt_svc,
+                        cache_control=cache_control,
+                        etag=etag,
+                        last_modified=last_modified,
+                        age=age,
+                        request_id=request_id,
+                        assertion_results=assertion_results,
+                        dns_resolve_ms=dns_ms if dns_error is None else None,
+                        dns_resolver_ip=self.dns_resolver_ip,
+                        compressed_size_bytes=compressed_size,
+                        redirect_timings=redirect_timings,
+                        http2_expected=http2_expected,
+                        http2_downgraded=http2_downgraded,
+                        query_params=self.query_params,
+                    )
+
+                    # Populate connection-level metrics from the timing backend
+                    metrics = transport.get_connection_metrics()
+                    result.tcp_connect_ms = metrics.get("tcp_connect_ms")
+                    result.tls_handshake_ms = metrics.get("tls_handshake_ms")
+                    result.ip_version = metrics.get("ip_version")
+                    cert_der: Optional[bytes] = metrics.get("cert_der")
+                    if cert_der:
+                        (
+                            cert_days,
+                            cert_cn,
+                            issuer_cn,
+                            sans,
+                            wildcard,
+                        ) = _parse_cert_der(cert_der)
+                        result.cert_expiry_days = cert_days
+                        result.cert_cn = cert_cn
+                        result.cert_issuer_cn = issuer_cn
+                        result.cert_sans = sans
+                        result.cert_wildcard = wildcard
+
+                    await self._update_progress()
+                    return result
+
+            except httpx.TimeoutException:
+                if attempt == self.max_retries:
+                    end_time = time.time()
+                    assert self._lock is not None
+                    async with self._lock:
+                        self.failed_targets[target] += 1
+                    result = HTTPResult(
+                        target=target,
+                        method=self.method,
+                        start_time=start_time,
+                        end_time=end_time,
+                        total_ms=(end_time - start_time) * 1000,
+                        status=QueryStatus.TIMEOUT,
+                        iteration=iteration,
+                        attempt_number=attempt + 1,
+                        error_message="Request timeout",
+                        dns_resolve_ms=dns_ms if dns_error is None else None,
+                        dns_resolver_ip=self.dns_resolver_ip,
+                    )
+                    await self._update_progress()
+                    return result
+                await asyncio.sleep(
+                    self.retry_backoff_base**attempt * self.retry_backoff_multiplier
+                )
+
+            except ssl.SSLError as e:
+                end_time = time.time()
+                assert self._lock is not None
+                async with self._lock:
+                    self.failed_targets[target] += 1
+                result = HTTPResult(
+                    target=target,
+                    method=self.method,
+                    start_time=start_time,
+                    end_time=end_time,
+                    total_ms=(end_time - start_time) * 1000,
+                    status=QueryStatus.TLS_ERROR,
+                    iteration=iteration,
+                    attempt_number=attempt + 1,
+                    error_message=f"TLS error: {e}",
+                    dns_resolve_ms=dns_ms if dns_error is None else None,
+                    dns_resolver_ip=self.dns_resolver_ip,
+                )
+                await self._update_progress()
+                return result
+
+            except httpx.ConnectError as e:
+                end_time = time.time()
+                assert self._lock is not None
+                async with self._lock:
+                    self.failed_targets[target] += 1
+                result = HTTPResult(
+                    target=target,
+                    method=self.method,
+                    start_time=start_time,
+                    end_time=end_time,
+                    total_ms=(end_time - start_time) * 1000,
+                    status=QueryStatus.CONNECTION_REFUSED,
+                    iteration=iteration,
+                    attempt_number=attempt + 1,
+                    error_message=str(e),
+                    dns_resolve_ms=dns_ms if dns_error is None else None,
+                    dns_resolver_ip=self.dns_resolver_ip,
+                )
+                await self._update_progress()
+                return result
+
+            except Exception as e:
+                if attempt == self.max_retries:
+                    end_time = time.time()
+                    assert self._lock is not None
+                    async with self._lock:
+                        self.failed_targets[target] += 1
+                    result = HTTPResult(
+                        target=target,
+                        method=self.method,
+                        start_time=start_time,
+                        end_time=end_time,
+                        total_ms=(end_time - start_time) * 1000,
+                        status=QueryStatus.UNKNOWN_ERROR,
+                        iteration=iteration,
+                        attempt_number=attempt + 1,
+                        error_message=str(e),
+                        dns_resolve_ms=dns_ms if dns_error is None else None,
+                        dns_resolver_ip=self.dns_resolver_ip,
+                    )
+                    await self._update_progress()
+                    return result
+                await asyncio.sleep(
+                    self.retry_backoff_base**attempt * self.retry_backoff_multiplier
+                )
+
+        # Unreachable fallback
+        return HTTPResult(
+            target=target,
+            method=self.method,
+            start_time=start_time,
+            end_time=time.time(),
+            total_ms=0.0,
+            status=QueryStatus.UNKNOWN_ERROR,
+            iteration=iteration,
+            error_message="Exhausted retries",
+            dns_resolve_ms=dns_ms if dns_error is None else None,
+            dns_resolver_ip=self.dns_resolver_ip,
+        )
+
+    # ------------------------------------------------------------------
+    # Warmup
+    # ------------------------------------------------------------------
+
+    async def _run_warmup(self, targets: List[str]) -> List[HTTPResult]:
+        tasks = [self.request_single(t, iteration=0) for t in targets]
+        return list(await asyncio.gather(*tasks))
+
+    async def _run_fast_warmup(self, targets: List[str]) -> List[HTTPResult]:
+        original_method = self.method
+        self.method = "HEAD"
+        try:
+            tasks = [self.request_single(t, iteration=0) for t in targets]
+            results = list(await asyncio.gather(*tasks))
+        finally:
+            self.method = original_method
+        return results
+
+    # ------------------------------------------------------------------
+    # run_benchmark
+    # ------------------------------------------------------------------
+
+    async def run_benchmark(
+        self,
+        targets: List[str],
+        iterations: int = 1,
+        warmup: bool = False,
+        warmup_fast: bool = False,
+    ) -> List[HTTPResult]:
+        """Run benchmark across all targets for N iterations."""
+        if warmup_fast:
+            warmup_results = await self._run_fast_warmup(targets)
+        elif warmup:
+            warmup_results = await self._run_warmup(targets)
+        else:
+            warmup_results = []
+
+        for r in warmup_results:
+            if r.status != QueryStatus.SUCCESS:
+                import click
+
+                click.echo(warning(f"Warmup failed: {r.target} → {r.status.value}"))
+
+        self.query_counter = 0
+        self.total_queries = len(targets) * iterations
+
+        tasks = [
+            self.request_single(target, iteration=i + 1)
+            for i in range(iterations)
+            for target in targets
+        ]
+
+        results = await asyncio.gather(*tasks)
+        return list(results)

--- a/src/net_benchmark/http_bench/exporters.py
+++ b/src/net_benchmark/http_bench/exporters.py
@@ -1,0 +1,608 @@
+"""Export functionality for HTTP benchmark results."""
+
+import base64
+import json
+import os
+import tempfile
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+try:
+    from weasyprint import HTML
+except ImportError:
+    HTML = None
+
+from openpyxl import Workbook
+from openpyxl.styles import Font
+
+from net_benchmark.dns_benchmark.core import QueryStatus
+from net_benchmark.exporters.base import (
+    FILL_HEADER,
+    add_simple_table_sheet,
+    autosize_columns,
+    embed_charts_sheet,
+    generate_bar_chart,
+    html_page,
+)
+from net_benchmark.http_bench.analysis import HTTPAnalyzer
+from net_benchmark.http_bench.core import SECURITY_HEADERS, HTTPResult
+
+# ---------------------------------------------------------------------------
+# JSON bundle
+# ---------------------------------------------------------------------------
+
+
+class HTTPExportBundle:
+    @staticmethod
+    def export_json(
+        results: List[HTTPResult],
+        analyzer: HTTPAnalyzer,
+        output_path: str,
+    ) -> None:
+        payload = {
+            "overall": analyzer.get_overall_statistics(),
+            "target_stats": [vars(s) for s in analyzer.get_target_statistics()],
+            "protocol_distribution": analyzer.get_protocol_distribution(),
+            "ttfb_statistics": analyzer.get_ttfb_statistics(),
+            "security_summary": analyzer.get_security_summary(),
+            "status_code_distribution": analyzer.get_status_code_distribution(),
+            "error_stats": analyzer.get_error_statistics(),
+            "raw_results": [r.to_dict() for r in results],
+        }
+        with open(output_path, "w") as f:
+            json.dump(payload, f, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class HTTPCSVExporter:
+    """Mirrors dns_benchmark CSVExporter — one static method per export type."""
+
+    @staticmethod
+    def export_raw_results(results: List[HTTPResult], output_path: str) -> None:
+        df = pd.DataFrame([r.to_dict() for r in results])
+        df.to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_summary_statistics(analyzer: HTTPAnalyzer, output_path: str) -> None:
+        data = []
+        for s in analyzer.get_target_statistics():
+            data.append(
+                {
+                    "target": s.target,
+                    "method": s.method,
+                    "total_requests": s.total_requests,
+                    "successful_requests": s.successful_requests,
+                    "success_rate": s.success_rate,
+                    "min_latency_ms": s.min_latency,
+                    "avg_latency_ms": s.avg_latency,
+                    "median_latency_ms": s.median_latency,
+                    "max_latency_ms": s.max_latency,
+                    "p95_latency_ms": s.p95_latency,
+                    "p99_latency_ms": s.p99_latency,
+                    "jitter_ms": s.jitter,
+                    "consistency_score": s.consistency_score,
+                    "avg_ttfb_ms": s.avg_ttfb_ms,
+                    "p95_ttfb_ms": s.p95_ttfb_ms,
+                    "http2_rate": s.http2_rate,
+                    "redirect_rate": round(s.redirect_rate, 2),
+                    "avg_response_size_bytes": round(s.avg_response_size_bytes, 2),
+                    "avg_dns_ms": round(s.avg_dns_ms, 2),
+                    "avg_tcp_ms": round(s.avg_tcp_ms, 2),
+                    "avg_tls_ms": round(s.avg_tls_ms, 2),
+                    "avg_compressed_size_bytes": round(s.avg_compressed_size_bytes, 2),
+                    "avg_redirect_time_ms": round(s.avg_redirect_time_ms, 2),
+                    "http2_downgrade_rate": round(s.http2_downgrade_rate, 2),
+                    "cdn_fingerprint": s.cdn_fingerprint or "",
+                    "server_header": s.server_header or "",
+                    "cert_expiry_days_min": s.cert_expiry_days_min,
+                    "cache_control_present": s.cache_control_present,
+                    "etag_present": s.etag_present,
+                    "last_modified_present": s.last_modified_present,
+                    "age_present": s.age_present,
+                }
+            )
+        pd.DataFrame(data).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_security_statistics(analyzer: HTTPAnalyzer, output_path: str) -> None:
+        """Per‑target security header presence matrix."""
+        # Build presence matrix
+        matrix = []
+        for target_stat in analyzer.get_target_statistics():
+            target = target_stat.target
+            row = {"target": target}
+            # Get all raw results for this target (successful only)
+            for h in SECURITY_HEADERS:
+                present = False
+                for r in analyzer.results:
+                    if r.target == target and r.status == QueryStatus.SUCCESS:
+                        if r.security_headers.get(h) is not None:
+                            present = True
+                            break
+                row[h] = "✓" if present else "✗"
+            matrix.append(row)
+        pd.DataFrame(matrix).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_ttfb_statistics(analyzer: HTTPAnalyzer, output_path: str) -> None:
+        pd.DataFrame(analyzer.get_ttfb_statistics()).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_protocol_statistics(analyzer: HTTPAnalyzer, output_path: str) -> None:
+        pd.DataFrame(analyzer.get_protocol_distribution()).to_csv(
+            output_path, index=False
+        )
+
+    @staticmethod
+    def export_error_statistics(analyzer: HTTPAnalyzer, output_path: str) -> None:
+        errors = analyzer.get_error_statistics()
+        pd.DataFrame(
+            [{"error_message": k, "count": v} for k, v in errors.items()]
+        ).to_csv(output_path, index=False)
+
+
+# ---------------------------------------------------------------------------
+# Excel
+# ---------------------------------------------------------------------------
+
+
+class HTTPExcelExporter:
+    """Mirrors dns_benchmark ExcelExporter.
+    Uses base helpers — no duplicated sheet/chart code.
+    """
+
+    @staticmethod
+    def export_results(
+        results: List[HTTPResult],
+        analyzer: HTTPAnalyzer,
+        output_path: str,
+        error_stats: Optional[Dict[str, int]] = None,
+        include_charts: bool = False,
+    ) -> None:
+        wb = Workbook()
+        wb.remove(wb.active)
+
+        temp_dir = None
+        chart_paths: List[str] = []
+
+        try:
+            HTTPExcelExporter._add_raw_data_sheet(wb, results)
+            HTTPExcelExporter._add_target_summary_sheet(wb, analyzer)
+            HTTPExcelExporter._add_ttfb_sheet(wb, analyzer)
+            HTTPExcelExporter._add_security_headers_sheet(wb, analyzer)
+
+            proto_stats = analyzer.get_protocol_distribution()
+            if proto_stats:
+                add_simple_table_sheet(wb, "Protocol", pd.DataFrame(proto_stats))
+
+            status_dist = analyzer.get_status_code_distribution()
+            if status_dist:
+                add_simple_table_sheet(wb, "Status Codes", pd.DataFrame(status_dist))
+
+            if error_stats:
+                add_simple_table_sheet(
+                    wb,
+                    "Errors",
+                    pd.DataFrame(
+                        [{"error": k, "count": v} for k, v in error_stats.items()]
+                    ),
+                )
+
+            if include_charts:
+                temp_dir = tempfile.mkdtemp()
+                chart_paths = HTTPExcelExporter._add_charts_sheet(
+                    wb, analyzer, temp_dir
+                )
+
+            wb.save(output_path)
+        finally:
+            for p in chart_paths:
+                try:
+                    if os.path.exists(p):
+                        os.remove(p)
+                except OSError:
+                    pass
+            if temp_dir and os.path.exists(temp_dir):
+                try:
+                    os.rmdir(temp_dir)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _add_raw_data_sheet(wb: Workbook, results: List[HTTPResult]) -> None:
+        data = []
+        for r in results:
+            present_headers = "|".join(
+                h for h, v in r.security_headers.items() if v is not None
+            )
+            data.append(
+                {
+                    "Target": r.target,
+                    "Method": r.method,
+                    "Status": r.status.value,
+                    "HTTP Code": r.http_status_code or "",
+                    "Total (ms)": round(r.total_ms, 2),
+                    "TTFB (ms)": round(r.ttfb_ms, 2) if r.ttfb_ms else "",
+                    "Protocol": r.protocol.value,
+                    "Redirects": r.redirect_count,
+                    "Size (bytes)": r.response_size_bytes or "",
+                    "Compressed": r.compressed,
+                    "Content-Type": r.content_type or "",
+                    "CDN": r.cdn_fingerprint or "",
+                    "Server": r.server_header or "",
+                    "Cert Expiry (days)": (
+                        r.cert_expiry_days if r.cert_expiry_days is not None else ""
+                    ),
+                    "Alt-Svc": r.alt_svc or "",
+                    "IP Version": r.ip_version or "",
+                    "Security Headers": present_headers,
+                    "Iteration": r.iteration,
+                    "Attempt": r.attempt_number,
+                    "Error": r.error_message or "",
+                }
+            )
+        add_simple_table_sheet(wb, "Raw Data", pd.DataFrame(data))
+
+    @staticmethod
+    def _add_target_summary_sheet(wb: Workbook, analyzer: HTTPAnalyzer) -> None:
+        data = []
+        for s in analyzer.get_target_statistics():
+            data.append(
+                {
+                    "Target": s.target,
+                    "Method": s.method,
+                    "Total": s.total_requests,
+                    "Successful": s.successful_requests,
+                    "Success Rate (%)": round(s.success_rate, 2),
+                    "Avg (ms)": round(s.avg_latency, 2),
+                    "Median (ms)": round(s.median_latency, 2),
+                    "P95 (ms)": round(s.p95_latency, 2),
+                    "P99 (ms)": round(s.p99_latency, 2),
+                    "Jitter": round(s.jitter, 2),
+                    "Consistency": round(s.consistency_score, 2),
+                    "Avg TTFB (ms)": round(s.avg_ttfb_ms, 2),
+                    "HTTP/2 Rate (%)": round(s.http2_rate, 2),
+                    "Redirect Rate (%)": round(s.redirect_rate, 2),
+                    "Avg Size (bytes)": round(s.avg_response_size_bytes, 2),
+                    "Avg DNS (ms)": round(s.avg_dns_ms, 2),
+                    "Avg TCP (ms)": round(s.avg_tcp_ms, 2),
+                    "Avg TLS (ms)": round(s.avg_tls_ms, 2),
+                    "Avg Compressed Size (bytes)": round(
+                        s.avg_compressed_size_bytes, 2
+                    ),
+                    "Avg Redirect Time (ms)": round(s.avg_redirect_time_ms, 2),
+                    "HTTP/2 Downgrade Rate (%)": round(s.http2_downgrade_rate, 2),
+                    "Cache-Control": s.cache_control_present,
+                    "ETag": s.etag_present,
+                    "Last-Modified": s.last_modified_present,
+                    "Age": s.age_present,
+                    "CDN": s.cdn_fingerprint or "",
+                    "Server": s.server_header or "",
+                    "Cert Expiry (days)": (
+                        s.cert_expiry_days_min
+                        if s.cert_expiry_days_min is not None
+                        else ""
+                    ),
+                    "Alt-Svc": s.alt_svc or "",
+                    "IP Version": s.ip_version or "",
+                }
+            )
+        add_simple_table_sheet(wb, "Target Summary", pd.DataFrame(data))
+
+    @staticmethod
+    def _add_ttfb_sheet(wb: Workbook, analyzer: HTTPAnalyzer) -> None:
+        add_simple_table_sheet(
+            wb, "TTFB Analysis", pd.DataFrame(analyzer.get_ttfb_statistics())
+        )
+
+    @staticmethod
+    def _add_security_headers_sheet(wb: Workbook, analyzer: HTTPAnalyzer) -> None:
+        """Security headers presence sheet — one row per target, each header cell
+        coloured green (✓) or red (✗). Target column has no fill.
+        """
+        from openpyxl.styles import PatternFill
+
+        # Build per‑target presence from successful results only
+        per_target: Dict[str, Dict[str, bool]] = {}
+        for r in analyzer.results:
+            if r.status != QueryStatus.SUCCESS:
+                continue
+            if r.target not in per_target:
+                per_target[r.target] = {}
+            for h in SECURITY_HEADERS:
+                if r.security_headers.get(h) is not None:
+                    per_target[r.target][h] = True
+
+        headers_cols = ["Target"] + [
+            h.title().replace("-", " ") for h in SECURITY_HEADERS
+        ]
+        rows = []
+        for target_stat in analyzer.get_target_statistics():
+            target = target_stat.target
+            presence = per_target.get(target, {})
+            row = [target] + ["✓" if presence.get(h) else "✗" for h in SECURITY_HEADERS]
+            rows.append(row)
+
+        ws = wb.create_sheet("Security Headers")
+
+        # Write header row
+        for col_idx, header in enumerate(headers_cols, 1):
+            cell = ws.cell(row=1, column=col_idx, value=header)
+            cell.font = Font(bold=True)
+            cell.fill = FILL_HEADER
+
+        # Write data rows with per‑cell colours
+        green_fill = PatternFill(
+            start_color="C6EFCE", end_color="C6EFCE", fill_type="solid"
+        )
+        red_fill = PatternFill(
+            start_color="FFC7CE", end_color="FFC7CE", fill_type="solid"
+        )
+
+        for row_idx, row_values in enumerate(rows, 2):
+            for col_idx, value in enumerate(row_values, 1):
+                cell = ws.cell(row=row_idx, column=col_idx, value=value)
+                if col_idx == 1:  # Target column – no fill
+                    continue
+                cell.fill = green_fill if value == "✓" else red_fill
+
+        autosize_columns(ws)
+
+    @staticmethod
+    def _add_charts_sheet(
+        wb: Workbook, analyzer: HTTPAnalyzer, temp_dir: str
+    ) -> List[str]:
+        target_stats = analyzer.get_target_statistics()
+        valid = [s for s in target_stats if s.successful_requests > 0]
+
+        names = [s.target.replace("https://", "").replace("http://", "") for s in valid]
+
+        latency_path = generate_bar_chart(
+            names=names,
+            values=[s.avg_latency for s in valid],
+            ylabel="Avg Latency (ms)",
+            title="HTTP Target Latency Comparison",
+            output_path=os.path.join(temp_dir, "http_latency.png"),
+        )
+        ttfb_path = generate_bar_chart(
+            names=names,
+            values=[s.avg_ttfb_ms for s in valid],
+            ylabel="Avg TTFB (ms)",
+            title="Time to First Byte Comparison",
+            output_path=os.path.join(temp_dir, "http_ttfb.png"),
+        )
+        success_path = generate_bar_chart(
+            names=names,
+            values=[s.success_rate for s in valid],
+            ylabel="Success Rate (%)",
+            title="HTTP Target Success Rates",
+            output_path=os.path.join(temp_dir, "http_success.png"),
+            thresholds=(80.0, 95.0),
+            invert_colours=True,
+            value_fmt="{:.1f}%",
+        )
+
+        embed_charts_sheet(
+            wb,
+            "Charts",
+            [
+                ("A3", "A4", latency_path),
+                ("A23", "A24", ttfb_path),
+                ("A43", "A44", success_path),
+            ],
+            "HTTP Benchmark Charts",
+        )
+        return [latency_path, ttfb_path, success_path]
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+class HTTPPDFExporter:
+    """Mirrors dns_benchmark PDFExporter."""
+
+    @staticmethod
+    def export_results(
+        results: List[HTTPResult],
+        analyzer: HTTPAnalyzer,
+        output_path: str,
+        include_charts: bool = True,
+    ) -> None:
+        if HTML is None:
+            raise RuntimeError(
+                "PDF export requires 'weasyprint'. "
+                "Install with: pip install net-benchmark[pdf]"
+            )
+
+        charts_dir = tempfile.mkdtemp()
+        chart_paths: List[str] = []
+
+        try:
+            target_stats = analyzer.get_target_statistics()
+            valid = [s for s in target_stats if s.successful_requests > 0]
+            names = [
+                s.target.replace("https://", "").replace("http://", "") for s in valid
+            ]
+
+            # Generate all three charts
+            latency_path = generate_bar_chart(
+                names=names,
+                values=[s.avg_latency for s in valid],
+                ylabel="Avg Latency (ms)",
+                title="HTTP Target Latency Comparison",
+                output_path=os.path.join(charts_dir, "latency.png"),
+            )
+            ttfb_path = generate_bar_chart(
+                names=names,
+                values=[s.avg_ttfb_ms for s in valid],
+                ylabel="Avg TTFB (ms)",
+                title="Time to First Byte Comparison",
+                output_path=os.path.join(charts_dir, "ttfb.png"),
+            )
+            success_path = generate_bar_chart(
+                names=names,
+                values=[s.success_rate for s in valid],
+                ylabel="Success Rate (%)",
+                title="HTTP Target Success Rates",
+                output_path=os.path.join(charts_dir, "success.png"),
+                thresholds=(80.0, 95.0),
+                invert_colours=True,
+                value_fmt="{:.1f}%",
+            )
+            chart_paths.extend([latency_path, ttfb_path, success_path])
+
+            # Read images as base64
+            with open(latency_path, "rb") as f:
+                latency_b64 = base64.b64encode(f.read()).decode()
+            with open(ttfb_path, "rb") as f:
+                ttfb_b64 = base64.b64encode(f.read()).decode()
+            with open(success_path, "rb") as f:
+                success_b64 = base64.b64encode(f.read()).decode()
+
+            html_content = HTTPPDFExporter._generate_html(
+                analyzer, latency_b64, ttfb_b64, success_b64
+            )
+            HTML(string=html_content).write_pdf(output_path)
+
+        finally:
+            for p in chart_paths:
+                try:
+                    if os.path.exists(p):
+                        os.remove(p)
+                except OSError:
+                    pass
+            try:
+                os.rmdir(charts_dir)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _generate_html(
+        analyzer: HTTPAnalyzer,
+        latency_b64: str,
+        ttfb_b64: str,
+        success_b64: str,
+    ) -> str:
+        overall = analyzer.get_overall_statistics()
+        target_stats = analyzer.get_target_statistics()
+        security = analyzer.get_security_summary()
+        ranked = sorted(
+            [s for s in target_stats if s.successful_requests > 0],
+            key=lambda s: s.avg_latency,
+        )
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # --- target rankings table ---
+        ranking_rows = "".join(
+            f"<tr><td>{i + 1}</td><td>{s.target}</td>"
+            f"<td>{s.avg_latency:.1f}</td><td>{s.avg_ttfb_ms:.1f}</td>"
+            f"<td>{s.success_rate:.1f}%</td>"
+            f"<td>{'HTTP/2' if s.http2_rate > 50 else 'HTTP/1.1'}</td>"
+            f"<td>{s.ip_version or 'N/A'}</td>"
+            f"<td>{'✓' if s.alt_svc else '✗'}</td></tr>"
+            for i, s in enumerate(ranked)
+        )
+
+        # --- security summary table ---
+        header_counts = security.get("security_header_counts", {})
+        total_req = security.get("total_requests", 1)
+        sec_rows = "".join(
+            f"<tr><td>{h.title()}</td>"
+            f"<td>{header_counts.get(h, 0)}</td>"
+            f"<td>{header_counts.get(h, 0) / total_req * 100:.1f}%</td>"
+            f"<td class='{'badge-ok' if header_counts.get(h, 0) > 0 else 'badge-crit'}'>"
+            f"{'✓' if header_counts.get(h, 0) > 0 else '✗'}</td>"
+            f"</tr>"
+            for h in SECURITY_HEADERS
+        )
+
+        cdn_dist = security.get("cdn_distribution", {})
+        cdn_str = (
+            ", ".join(f"{k} ({v})" for k, v in cdn_dist.items()) or "None detected"
+        )
+
+        # Compute real minimum certificate expiry from target stats
+        min_expiry = None
+        for s in target_stats:
+            if s.cert_expiry_days_min is not None:
+                if min_expiry is None or s.cert_expiry_days_min < min_expiry:
+                    min_expiry = s.cert_expiry_days_min
+        cert_expiry_line = f"<p><strong>Cert expiry (worst):</strong> {min_expiry if min_expiry is not None else 'N/A'} days</p>"
+
+        # Collect alt_svc and ip_version signals from target stats
+        alt_svc_targets = [s for s in target_stats if s.alt_svc]
+        alt_svc_str = (
+            ", ".join(
+                f"{s.target.replace('https://', '').replace('http://', '')}: {s.alt_svc}"
+                for s in alt_svc_targets
+            )
+            or "None detected"
+        )
+
+        ip_versions = set(s.ip_version for s in target_stats if s.ip_version)
+        ip_version_str = ", ".join(sorted(ip_versions)) or "N/A"
+
+        body = f"""
+        <div class="header">
+        <h1>HTTP Benchmark Report</h1>
+        <p>Generated: {now}</p>
+        </div>
+
+        <div class="section">
+        <h2>Executive Summary</h2>
+        <p><strong>Total requests:</strong> {overall['total_requests']}</p>
+        <p><strong>Successful:</strong> {overall['successful_requests']} ({overall['overall_success_rate']:.1f}%)</p>
+        <p><strong>Avg latency:</strong> {overall['overall_avg_latency']:.1f} ms</p>
+        <p><strong>Avg TTFB:</strong> {overall['overall_avg_ttfb']:.1f} ms</p>
+        <p><strong>HTTP/2 rate:</strong> {overall['http2_rate']:.1f}%</p>
+        <p><strong>HSTS coverage:</strong> {overall['hsts_coverage']:.1f}%</p>
+        <p><strong>Targets tested:</strong> {overall['target_count']}</p>
+        <p><strong>Fastest target:</strong> {overall['fastest_target']}</p>
+        <p><strong>Slowest target:</strong> {overall['slowest_target']}</p>
+        {cert_expiry_line}
+        <p><strong>IP version(s):</strong> {ip_version_str}</p>
+        <p><strong>HTTP/3 advertised (Alt-Svc):</strong> {alt_svc_str}</p>
+        </div>
+
+        <div class="section">
+        <h2>Latency Comparison</h2>
+        <div class="chart"><img src="data:image/png;base64,{latency_b64}" alt="Latency Comparison"></div>
+        </div>
+
+        <div class="section">
+        <h2>Time to First Byte (TTFB)</h2>
+        <div class="chart"><img src="data:image/png;base64,{ttfb_b64}" alt="TTFB Comparison"></div>
+        </div>
+
+        <div class="section">
+        <h2>Success Rates</h2>
+        <div class="chart"><img src="data:image/png;base64,{success_b64}" alt="Success Rate Comparison"></div>
+        </div>
+
+        <div class="section">
+        <h2>Target Rankings</h2>
+        <table>
+        <tr><th>Rank</th><th>Target</th><th>Avg (ms)</th><th>TTFB (ms)</th><th>Success</th><th>Protocol</th><th>IP Ver</th><th>HTTP/3</th></tr>
+            {ranking_rows}
+        </table>
+        </div>
+
+        <div class="section">
+        <h2>Security Headers Audit</h2>
+        <p><strong>CDN detected:</strong> {cdn_str}</p>
+        <p><strong>Server header leaks:</strong> {security.get('server_header_leak_count', 0)}</p>
+        <table>
+            <tr><th>Header</th><th>Present Count</th><th>Coverage</th><th>Status</th></tr>
+            {sec_rows}
+        </table>
+        </div>
+        """
+        return html_page("HTTP Benchmark Report", body)

--- a/src/net_benchmark/http_bench/sample_data/Readme.txt
+++ b/src/net_benchmark/http_bench/sample_data/Readme.txt
@@ -1,0 +1,1 @@
+Testing data

--- a/src/net_benchmark/http_bench/sample_data/targets.txt
+++ b/src/net_benchmark/http_bench/sample_data/targets.txt
@@ -1,0 +1,9 @@
+# Popular domains for HTTP benchmarking
+https://stackoverflow.com
+https://github.com
+https://www.microsoft.com
+https://www.amazon.com
+https://www.mozilla.org
+https://www.nytimes.com
+https://www.reddit.com
+https://httpbin.org/get

--- a/src/net_benchmark/http_bench/tests/conftest.py
+++ b/src/net_benchmark/http_bench/tests/conftest.py
@@ -1,0 +1,84 @@
+import time
+from typing import List
+
+import pytest
+
+from net_benchmark.http_bench.analysis import HTTPAnalyzer
+from net_benchmark.http_bench.core import (
+    HTTPProtocol,
+    HTTPResult,
+    QueryStatus,
+)
+
+
+@pytest.fixture
+def sample_success_result() -> HTTPResult:
+    """A minimal successful result."""
+    now = time.time()
+    return HTTPResult(
+        target="https://example.com",
+        method="GET",
+        start_time=now,
+        end_time=now + 0.1,
+        total_ms=100.0,
+        status=QueryStatus.SUCCESS,
+        iteration=1,
+        attempt_number=1,
+        http_status_code=200,
+        protocol=HTTPProtocol.HTTP2,
+        alpn_negotiated="h2",
+        ttfb_ms=50.0,
+        ttlb_ms=100.0,
+        response_size_bytes=1024,
+        compressed=True,
+        content_encoding="gzip",
+        content_type="text/html",
+        security_headers={
+            "strict-transport-security": "max-age=31536000",
+            "content-security-policy": None,
+        },
+        cdn_fingerprint="Cloudflare",
+        server_header="cloudflare",
+        cert_expiry_days=365,
+        cert_cn="example.com",
+        alt_svc='h3=":443"',
+        ip_version="IPv4",
+        tcp_connect_ms=10.0,
+        tls_handshake_ms=20.0,
+        dns_resolve_ms=5.0,
+        dns_resolver_ip="8.8.8.8",
+        cache_control="public, max-age=3600",
+        etag='"abc"',
+        last_modified="Wed, 21 Oct 2015 07:28:00 GMT",
+        age="123",
+        assertion_results={"status_code": True},
+    )
+
+
+@pytest.fixture
+def sample_error_result() -> HTTPResult:
+    """A failed result."""
+    now = time.time()
+    return HTTPResult(
+        target="https://example.com",
+        method="GET",
+        start_time=now,
+        end_time=now + 5,
+        total_ms=5000.0,
+        status=QueryStatus.TIMEOUT,
+        iteration=1,
+        attempt_number=1,
+        error_message="Request timeout",
+    )
+
+
+@pytest.fixture
+def sample_results(sample_success_result, sample_error_result) -> List[HTTPResult]:
+    """Mix of success and failure."""
+    return [sample_success_result, sample_error_result]
+
+
+@pytest.fixture
+def analyzer(sample_results) -> HTTPAnalyzer:
+    """HTTPAnalyzer instantiated with two results."""
+    return HTTPAnalyzer(sample_results)

--- a/src/net_benchmark/http_bench/tests/test_analysis.py
+++ b/src/net_benchmark/http_bench/tests/test_analysis.py
@@ -1,0 +1,97 @@
+from net_benchmark.http_bench.analysis import HTTPAnalyzer
+from net_benchmark.http_bench.core import HTTPProtocol, HTTPResult, QueryStatus
+
+
+def test_create_dataframe(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    df = analyzer.df
+    assert len(df) == 2
+    assert set(df.columns) >= {"target", "total_ms", "status", "completed"}
+
+
+def test_get_target_statistics(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    stats = analyzer.get_target_statistics()
+    assert len(stats) == 1  # both results for same target
+    s = stats[0]
+    assert s.total_requests == 2
+    assert s.successful_requests == 1
+    assert s.success_rate == 50.0
+    assert s.avg_latency == 100.0
+    assert s.avg_ttfb_ms == 50.0
+    assert s.http2_rate == 100.0
+    assert s.cdn_fingerprint == "Cloudflare"
+    assert s.cache_control_present == 1
+    assert s.etag_present == 1
+    assert s.last_modified_present == 1
+    assert s.age_present == 1
+
+
+def test_consistency_single_sample():
+    """Test that consistency is 100% with one success."""
+    r = create_success_result(total_ms=50)
+    analyzer = HTTPAnalyzer([r])
+    stats = analyzer.get_target_statistics()
+    assert len(stats) == 1
+    assert stats[0].consistency_score == 100.0
+    assert stats[0].jitter == 0.0
+
+
+def test_get_overall_statistics(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    overall = analyzer.get_overall_statistics()
+    assert overall["total_requests"] == 2
+    assert overall["successful_requests"] == 1
+    assert overall["overall_success_rate"] == 50.0
+    assert overall["overall_avg_latency"] == 100.0
+    assert overall["overall_avg_ttfb"] == 50.0
+    assert overall["fastest_target"] == "https://example.com"
+    assert overall["assertion_pass_rate"] == 50.0  # one passed, one no assertions
+
+
+def test_get_ttfb_statistics(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    ttfb = analyzer.get_ttfb_statistics()
+    assert len(ttfb) == 1
+    assert ttfb[0]["avg_ttfb_ms"] == 50.0
+
+
+def test_get_protocol_distribution(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    dist = analyzer.get_protocol_distribution()
+    protocols = {d["protocol"] for d in dist}
+    assert protocols == {"HTTP/2", "unknown"}
+
+
+def test_get_security_summary(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    sec = analyzer.get_security_summary()
+    assert sec["security_header_counts"]["strict-transport-security"] == 1
+    assert "Cloudflare" in sec["cdn_distribution"]
+
+
+def test_get_status_code_distribution(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    codes = analyzer.get_status_code_distribution()
+    assert any(c["status_code"] == 200 for c in codes)
+
+
+def test_get_error_statistics(sample_results):
+    analyzer = HTTPAnalyzer(sample_results)
+    errors = analyzer.get_error_statistics()
+    assert "Request timeout" in errors
+
+
+def create_success_result(total_ms: float) -> HTTPResult:
+    return HTTPResult(
+        target="https://example.com",
+        method="GET",
+        start_time=1.0,
+        end_time=1.0 + total_ms / 1000.0,
+        total_ms=total_ms,
+        status=QueryStatus.SUCCESS,
+        iteration=1,
+        attempt_number=1,
+        http_status_code=200,
+        protocol=HTTPProtocol.HTTP2,
+    )

--- a/src/net_benchmark/http_bench/tests/test_cli.py
+++ b/src/net_benchmark/http_bench/tests/test_cli.py
@@ -1,0 +1,910 @@
+"""CLI integration tests for http benchmark commands."""
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from net_benchmark.http_bench.cli import http
+from net_benchmark.http_bench.core import HTTPProtocol, HTTPResult, QueryStatus
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def make_success_result(target="https://example.com", total_ms=100):
+    """Create a minimal successful HTTPResult for test purposes."""
+    return HTTPResult(
+        target=target,
+        method="GET",
+        start_time=1.0,
+        end_time=1.0 + total_ms / 1000.0,
+        total_ms=total_ms,
+        status=QueryStatus.SUCCESS,
+        iteration=1,
+        attempt_number=1,
+        http_status_code=200,
+        protocol=HTTPProtocol.HTTP2,
+        alpn_negotiated="h2",
+        ttfb_ms=50.0,
+        response_size_bytes=1024,
+        compressed=True,
+        content_encoding="gzip",
+        content_type="text/html",
+        security_headers={"strict-transport-security": "max-age=31536000"},
+        cdn_fingerprint="Cloudflare",
+        server_header="cloudflare",
+        cert_expiry_days=365,
+        cert_cn="example.com",
+        ip_version="IPv4",
+        tcp_connect_ms=10.0,
+        tls_handshake_ms=20.0,
+        dns_resolve_ms=5.0,
+        dns_resolver_ip="8.8.8.8",
+        cache_control="public, max-age=3600",
+        etag='"abc"',
+        last_modified="Wed, 21 Oct 2015 07:28:00 GMT",
+        age="123",
+        assertion_results={},
+    )
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_run_benchmark(monkeypatch):
+    """Fixture that patches HTTPBenchmarkEngine.run_benchmark to return a list of fake results."""
+
+    async def _mock_run(self, targets, iterations=1, warmup=False, warmup_fast=False):
+        # Return one success per target per iteration
+        results = []
+        for i in range(iterations):
+            for t in targets:
+                results.append(make_success_result(target=t))
+        return results
+
+    monkeypatch.setattr(
+        "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+        _mock_run,
+    )
+    # Also mock close to avoid warnings
+    monkeypatch.setattr(
+        "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+        AsyncMock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# benchmark command
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmark:
+    def test_missing_targets(self, runner):
+        result = runner.invoke(http, ["benchmark"])
+        assert result.exit_code == 0
+        assert "Provide --targets" in result.output
+
+    def test_use_defaults(self, runner, mock_run_benchmark):
+        result = runner.invoke(http, ["benchmark", "--use-defaults", "--quiet"])
+        assert result.exit_code == 0
+        # Should have created files
+        assert os.path.exists("benchmark_results")
+        # At least one CSV
+        files = os.listdir("benchmark_results")
+        assert any(f.endswith(".csv") for f in files)
+        # Clean up
+        for f in files:
+            os.remove(os.path.join("benchmark_results", f))
+        os.rmdir("benchmark_results")
+
+    def test_invalid_format(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--formats", "xml"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid format" in result.output
+
+    def test_file_not_found(self, runner):
+        result = runner.invoke(http, ["benchmark", "--targets", "nonexistent.txt"])
+        assert result.exit_code == 0
+        assert "Target file not found" in result.output
+
+    def test_inline_targets(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--targets",
+                "https://a.com,https://b.com",
+                "--iterations",
+                "2",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+        # Should have completed successfully
+
+    def test_with_headers(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--use-defaults",
+                "--headers",
+                "Authorization:Bearer token,X-Custom:value",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_with_body(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--use-defaults",
+                "--method",
+                "POST",
+                "--body",
+                '{"key":"value"}',
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_body_and_body_file_conflict(self, runner):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--use-defaults",
+                "--body",
+                "test",
+                "--body-file",
+                "payload.json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Provide either --body or --body-file" in result.output
+
+    def test_body_file_not_found(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--body-file", "missing.json"]
+        )
+        assert result.exit_code == 0
+        assert "Cannot read body file" in result.output
+
+    def test_basic_auth(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            ["benchmark", "--use-defaults", "--auth", "basic:user:pass", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+    def test_bearer_auth(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            ["benchmark", "--use-defaults", "--auth", "bearer:token123", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+    def test_invalid_auth_format(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--auth", "digest:user:pass"]
+        )
+        assert result.exit_code == 0
+        assert "Unknown auth type" in result.output
+
+    def test_invalid_basic_auth_format(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--auth", "basic:user"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid basic auth format" in result.output
+
+    def test_invalid_bearer_auth_format(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--auth", "bearer"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid bearer auth format" in result.output
+
+    def test_cookies(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--use-defaults",
+                "--cookie",
+                "session=abc",
+                "--cookie",
+                "region=us",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_invalid_cookie(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--cookie", "invalid"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid cookie" in result.output
+
+    def test_user_agent(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            ["benchmark", "--use-defaults", "--user-agent", "TestBot/1.0", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+    def test_proxy(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            ["benchmark", "--use-defaults", "--proxy", "http://proxy:8080", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+    def test_sni_override(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--sni", "example.com", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_local_address(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            ["benchmark", "--use-defaults", "--local-address", "127.0.0.1", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+    def test_inject_request_id(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--inject-request-id", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_assertions(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http,
+            [
+                "benchmark",
+                "--use-defaults",
+                "--assert",
+                "status=200",
+                "--assert",
+                "body_contains=test",
+                "--assert",
+                "header_exists=X-Cache",
+                "--assert",
+                "max_latency=1000",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_invalid_assertion_format(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--assert", "bad_assertion"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid assertion" in result.output
+
+    def test_unknown_assertion_type(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--assert", "unknown=value"]
+        )
+        assert result.exit_code == 0
+        assert "Unknown assertion type" in result.output
+
+    def test_max_latency_non_numeric(self, runner):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--assert", "max_latency=abc"]
+        )
+        assert result.exit_code == 0
+        assert "max_latency must be a number" in result.output
+
+    def test_json_export(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--json", "--quiet"]
+        )
+        assert result.exit_code == 0
+        # Should have created a JSON file
+        files = os.listdir("benchmark_results")
+        assert any(f.endswith(".json") for f in files)
+        for f in files:
+            os.remove(os.path.join("benchmark_results", f))
+        os.rmdir("benchmark_results")
+
+    def test_pdf_export_without_weasyprint(
+        self, runner, mock_run_benchmark, monkeypatch
+    ):
+        # Simulate PDF export failure
+        def mock_pdf_export(*args, **kwargs):
+            raise RuntimeError("weasyprint not installed")
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPPDFExporter.export_results",
+            mock_pdf_export,
+        )
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--formats", "pdf", "--quiet"]
+        )
+        assert result.exit_code == 0
+        assert "PDF export failed" in result.output
+
+    def test_warmup_fast(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--warmup-fast", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_warmup_full(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--warmup", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_no_http2(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--no-http2", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_no_verify_ssl(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--no-verify-ssl", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+    def test_include_charts(self, runner, mock_run_benchmark):
+        result = runner.invoke(
+            http, ["benchmark", "--use-defaults", "--include-charts", "--quiet"]
+        )
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# monitoring command
+# ---------------------------------------------------------------------------
+
+
+class TestMonitoring:
+    def test_missing_targets(self, runner):
+        result = runner.invoke(http, ["monitoring"])
+        assert result.exit_code == 0
+        assert "Provide --targets" in result.output
+
+    def test_use_defaults_one_cycle(self, runner, monkeypatch):
+        # Mock the engine's run_benchmark and close to avoid real network
+        async def mock_run(
+            self, targets, iterations=1, warmup=False, warmup_fast=False
+        ):
+            return [make_success_result(t) for t in targets]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        # To stop after one cycle, we can set duration=1 (but duration check uses time.time, so we can just let it run one cycle and then interrupt with a side effect)
+        # We'll use a side effect that raises KeyboardInterrupt after the first loop
+        call_count = 0
+
+        def limited_sleep(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                raise KeyboardInterrupt()
+
+        monkeypatch.setattr("time.sleep", limited_sleep)
+        # Also mock time.time to avoid real waiting? Not needed because sleep is intercepted.
+        result = runner.invoke(
+            http, ["monitoring", "--use-defaults", "--interval", "0"]
+        )
+        assert result.exit_code == 0
+        assert "Monitoring stopped by user" in result.output
+
+    def test_invalid_targets_file(self, runner):
+        result = runner.invoke(http, ["monitoring", "--targets", "nonexistent.txt"])
+        assert result.exit_code == 0
+        assert "Error loading targets" in result.output
+
+    def test_with_alerts(self, runner, monkeypatch):
+        async def mock_run(
+            self, targets, iterations=1, warmup=False, warmup_fast=False
+        ):
+            return [make_success_result(t) for t in targets]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        # Force stop after one iteration
+        monkeypatch.setattr("time.sleep", lambda s: exec("raise KeyboardInterrupt()"))
+        result = runner.invoke(
+            http,
+            [
+                "monitoring",
+                "--use-defaults",
+                "--alert-latency",
+                "10",
+                "--alert-failure-rate",
+                "5",
+                "--interval",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Monitoring stopped by user" in result.output
+
+
+# ---------------------------------------------------------------------------
+# top command
+# ---------------------------------------------------------------------------
+
+
+class TestTop:
+    def test_missing_targets(self, runner):
+        result = runner.invoke(http, ["top"])
+        assert result.exit_code == 0
+        assert "Provide --targets" in result.output
+
+    def test_use_defaults(self, runner, monkeypatch):
+        # Mock the engine's run_benchmark to return a couple of results
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com", total_ms=100),
+                make_success_result(target="https://b.com", total_ms=200),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        result = runner.invoke(http, ["top", "--use-defaults", "--limit", "2"])
+        assert result.exit_code == 0
+        # The output strips the scheme, so we check for the hostname
+        assert "a.com" in result.output
+        assert "b.com" in result.output
+
+    def test_inline_targets(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://example.com", total_ms=50),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        result = runner.invoke(
+            http, ["top", "--targets", "https://example.com", "--limit", "1"]
+        )
+        assert result.exit_code == 0
+        assert "example.com" in result.output
+
+    def test_file_not_found(self, runner):
+        result = runner.invoke(http, ["top", "--targets", "nonexistent.txt"])
+        assert result.exit_code == 0
+        assert "Error loading targets" in result.output
+
+    def test_metric_ttfb(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com", total_ms=100),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        result = runner.invoke(
+            http, ["top", "--use-defaults", "--metric", "ttfb", "--limit", "1"]
+        )
+        assert result.exit_code == 0
+
+    def test_metric_success(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com", total_ms=100),
+                make_success_result(target="https://b.com", total_ms=200),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark",
+            mock_run,
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
+            AsyncMock(),
+        )
+        result = runner.invoke(
+            http, ["top", "--use-defaults", "--metric", "success", "--limit", "2"]
+        )
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# compare command
+# ---------------------------------------------------------------------------
+
+
+class TestCompare:
+    def test_need_at_least_two_targets(self, runner):
+        result = runner.invoke(http, ["compare", "https://a.com"])
+        assert result.exit_code == 0
+        assert "Need at least 2 targets" in result.output
+
+    def test_basic_comparison(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com", total_ms=100),
+                make_success_result(target="https://a.com", total_ms=110),
+                make_success_result(target="https://b.com", total_ms=200),
+                make_success_result(target="https://b.com", total_ms=190),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        # Do not use --quiet; we want to see the output
+        result = runner.invoke(
+            http, ["compare", "https://a.com", "https://b.com", "--iterations", "2"]
+        )
+        assert result.exit_code == 0
+        assert "a.com" in result.output
+        assert "b.com" in result.output
+
+    def test_auto_scheme(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            targets = kwargs.get("targets", [])
+            return [make_success_result(target=t) for t in targets]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(
+            http, ["compare", "example.com", "httpbin.org", "--iterations", "1"]
+        )
+        assert result.exit_code == 0
+        assert "example.com" in result.output
+        assert "httpbin.org" in result.output
+
+    def test_show_details(self, runner, monkeypatch):
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com", total_ms=100),
+                make_success_result(target="https://a.com", total_ms=110),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "https://a.com",
+                "https://b.com",
+                "--iterations",
+                "2",
+                "--show-details",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Iter 1:" in result.output
+        assert "Iter 2:" in result.output
+
+    def test_headers_parsing(self, runner, monkeypatch):
+        """Cover header parsing inside compare."""
+
+        async def mock_run(self, *args, **kwargs):
+            return [make_success_result(target="https://a.com") for _ in range(2)]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--headers",
+                "X-Custom:value,Authorization:Bearer tok",
+                "--iterations",
+                "1",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_body_file_success(self, runner, monkeypatch, tmp_path):
+        """Cover body-file success path."""
+        payload = tmp_path / "payload.json"
+        payload.write_text('{"test":true}')
+
+        async def mock_run(self, *args, **kwargs):
+            return [make_success_result(target="https://a.com") for _ in range(2)]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--body-file",
+                str(payload),
+                "--iterations",
+                "1",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_body_file_not_found(self, runner):
+        """Cover body-file error branch."""
+        result = runner.invoke(
+            http, ["compare", "a.com", "b.com", "--body-file", "nonexistent.json"]
+        )
+        assert result.exit_code == 0
+        assert "Cannot read body file" in result.output
+
+    def test_body_content_type_auto_json(self, runner, monkeypatch):
+        """Cover auto JSON content-type detection."""
+
+        async def mock_run(self, *args, **kwargs):
+            return [make_success_result(target="https://a.com") for _ in range(2)]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        # Inline JSON body without content-type header
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--body",
+                '{"key":"val"}',
+                "--iterations",
+                "1",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_body_file_json_extension(self, runner, monkeypatch, tmp_path):
+        """Cover auto JSON content-type from .json file extension."""
+        payload = tmp_path / "data.json"
+        payload.write_text("{}")
+
+        async def mock_run(self, *args, **kwargs):
+            return [make_success_result(target="https://a.com") for _ in range(2)]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--body-file",
+                str(payload),
+                "--iterations",
+                "1",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_auth_basic_invalid(self, runner):
+        """Cover invalid basic auth format in compare."""
+        result = runner.invoke(
+            http, ["compare", "a.com", "b.com", "--auth", "basic:user"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid basic auth format" in result.output
+
+    def test_auth_bearer_invalid(self, runner):
+        """Cover invalid bearer auth format."""
+        result = runner.invoke(http, ["compare", "a.com", "b.com", "--auth", "bearer"])
+        assert result.exit_code == 0
+        assert "Invalid bearer auth format" in result.output
+
+    def test_auth_unknown_type(self, runner):
+        """Cover unknown auth type."""
+        result = runner.invoke(
+            http, ["compare", "a.com", "b.com", "--auth", "digest:user:pass"]
+        )
+        assert result.exit_code == 0
+        assert "Unknown auth type" in result.output
+
+    def test_cookie_invalid(self, runner):
+        """Cover invalid cookie format."""
+        result = runner.invoke(
+            http, ["compare", "a.com", "b.com", "--cookie", "badcookie"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid cookie" in result.output
+
+    def test_export_txt(self, runner, monkeypatch, tmp_path):
+        """Cover .txt export branch."""
+
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com"),
+                make_success_result(target="https://b.com"),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        out_file = tmp_path / "comp.txt"
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--iterations",
+                "1",
+                "--quiet",
+                "--output",
+                str(out_file),
+            ],
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+
+    def test_export_json(self, runner, monkeypatch, tmp_path):
+        """Cover JSON export branch explicitly (already exist but may need coverage)."""
+
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com"),
+                make_success_result(target="https://b.com"),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        out_file = tmp_path / "comp.json"
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--iterations",
+                "1",
+                "--quiet",
+                "--output",
+                str(out_file),
+            ],
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+
+    def test_export_csv(self, runner, monkeypatch, tmp_path):
+        """Cover CSV export branch explicitly."""
+
+        async def mock_run(self, *args, **kwargs):
+            return [
+                make_success_result(target="https://a.com"),
+                make_success_result(target="https://b.com"),
+            ]
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        out_file = tmp_path / "comp.csv"
+        result = runner.invoke(
+            http,
+            [
+                "compare",
+                "a.com",
+                "b.com",
+                "--iterations",
+                "1",
+                "--quiet",
+                "--output",
+                str(out_file),
+            ],
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+
+    def test_compare_interrupted(self, runner, monkeypatch):
+        """Cover KeyboardInterrupt exception handling."""
+
+        async def mock_run(self, *args, **kwargs):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(http, ["compare", "a.com", "b.com", "--iterations", "1"])
+        assert result.exit_code == 0
+        assert "Comparison interrupted by user" in result.output
+
+    def test_compare_generic_exception(self, runner, monkeypatch):
+        """Cover generic exception handling."""
+
+        async def mock_run(self, *args, **kwargs):
+            raise RuntimeError("test error")
+
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.run_benchmark", mock_run
+        )
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close", AsyncMock()
+        )
+        result = runner.invoke(http, ["compare", "a.com", "b.com", "--iterations", "1"])
+        assert result.exit_code == 1
+        assert "Error during comparison: test error" in result.output

--- a/src/net_benchmark/http_bench/tests/test_core.py
+++ b/src/net_benchmark/http_bench/tests/test_core.py
@@ -1,0 +1,442 @@
+import ssl
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from httpcore._backends.base import (
+    AsyncNetworkStream,
+)
+
+from net_benchmark.http_bench.core import (
+    HTTPBenchmarkEngine,
+    HTTPResult,
+    MetricsCapturingTransport,
+    QueryStatus,
+    TargetManager,
+    TimingNetworkBackend,
+    TimingNetworkStream,
+    _parse_cert_der,
+)
+
+
+class TestTargetManager:
+    def test_default_targets(self):
+        defaults = TargetManager.get_default_targets()
+        assert len(defaults) > 3
+        for url in defaults:
+            assert url.startswith("https://")
+
+    def test_parse_inline(self):
+        mgr = TargetManager.parse_targets_input("https://a.com, https://b.com")
+        assert mgr.targets == ["https://a.com", "https://b.com"]
+
+    def test_parse_single_url(self):
+        mgr = TargetManager.parse_targets_input("https://example.com")
+        assert mgr.targets == ["https://example.com"]
+
+    def test_parse_file(self, tmp_path):
+        f = tmp_path / "targets.txt"
+        f.write_text("# comment\nhttps://example.com\n")
+        mgr = TargetManager.parse_targets_input(str(f))
+        assert mgr.targets == ["https://example.com"]
+
+    def test_parse_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            TargetManager.parse_targets_input("nonexistent.txt")
+
+    def test_empty_input_raises(self):
+        with pytest.raises(ValueError):
+            TargetManager.parse_targets_input("")
+
+
+class TestHTTPResult:
+    def test_to_dict(self):
+        r = HTTPResult(
+            target="https://x.com",
+            method="GET",
+            start_time=1.0,
+            end_time=1.1,
+            total_ms=100.0,
+            status=QueryStatus.SUCCESS,
+        )
+        d = r.to_dict()
+        assert d["target"] == "https://x.com"
+        assert d["status"] == "success"
+        assert d["protocol"] == "unknown"
+
+
+class TestParseCertDER:
+    def test_parse_valid_cert(self, sample_success_result):
+        # We need actual DER bytes; sample_success_result doesn't have cert_der.
+        # We'll test with a known cert later if needed.
+        pass
+
+    def test_parse_invalid_der(self):
+        days, cn, issuer, sans, wildcard = _parse_cert_der(b"not_a_cert")
+        assert days is None
+        assert cn is None
+        assert issuer is None
+        assert sans == []
+        assert wildcard is False
+
+
+class TestHTTPBenchmarkEngine:
+    @pytest.mark.asyncio
+    async def test_resolve_host(self):
+        engine = HTTPBenchmarkEngine()
+        ms, error = await engine._resolve_host("localhost")
+        assert error is None
+        assert ms > 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_host_failure(self):
+        engine = HTTPBenchmarkEngine()
+        ms, error = await engine._resolve_host("invalid.ghost")
+        # May resolve to None or raise; handle gracefully.
+        # Just check that it returns a tuple with ms and error if something goes wrong.
+        assert isinstance(ms, float)
+
+    @pytest.mark.asyncio
+    async def test_request_single_success(self, monkeypatch):
+        """Mock the httpx client to return a success response."""
+        engine = HTTPBenchmarkEngine()
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.is_success = True
+        fake_response.is_redirect = False
+        fake_response.http_version = "HTTP/2"
+        fake_response.headers = {
+            "content-encoding": "gzip",
+            "content-type": "text/html",
+        }
+        fake_response.aread = AsyncMock(return_value=b"<html></html>")
+        fake_response.history = []
+        fake_response.url = "https://example.com"
+
+        class FakeStreamContext:
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                return FakeStreamContext(fake_response)
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client(url):
+            return FakeClient(), MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single("https://example.com")
+        assert result.status == QueryStatus.SUCCESS
+        assert result.http_status_code == 200
+        assert result.total_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_request_single_timeout(self, monkeypatch):
+        engine = HTTPBenchmarkEngine(max_retries=0)
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                raise httpx.TimeoutException("timeout")
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client(url):
+            return FakeClient(), MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single("https://example.com")
+        assert result.status == QueryStatus.TIMEOUT
+
+    def test_get_transport_reuses(self):
+        engine = HTTPBenchmarkEngine()
+        t1 = engine._get_transport("https://example.com")
+        t2 = engine._get_transport("https://example.com")
+        assert t1 is t2
+
+    def test_get_transport_different_origins(self):
+        engine = HTTPBenchmarkEngine()
+        t1 = engine._get_transport("https://a.com")
+        t2 = engine._get_transport("https://b.com")
+        assert t1 is not t2
+
+    @pytest.mark.asyncio
+    async def test_get_client_reuses(self):
+        engine = HTTPBenchmarkEngine()
+        c1, t1 = await engine._get_client("https://example.com")
+        c2, t2 = await engine._get_client("https://example.com")
+        assert c1 is c2
+        assert t1 is t2
+
+    @pytest.mark.asyncio
+    async def test_get_client_different_origins(self):
+        engine = HTTPBenchmarkEngine()
+        c1, _ = await engine._get_client("https://a.com")
+        c2, _ = await engine._get_client("https://b.com")
+        assert c1 is not c2
+
+    def test_run_assertions(self):
+        engine = HTTPBenchmarkEngine(
+            assertions={
+                "status_code": 200,
+                "body_contains": "ok",
+                "header_exists": "X-Test",
+            }
+        )
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-Test": "1"}
+        body = b"everything is ok"
+        results = engine._run_assertions(response, body)
+        assert results == {
+            "status_code": True,
+            "body_contains": True,
+            "header_exists": True,
+        }
+
+    def test_run_assertions_failures(self):
+        engine = HTTPBenchmarkEngine(assertions={"status_code": 201})
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {}
+        body = b""
+        results = engine._run_assertions(response, body)
+        assert results["status_code"] is False
+
+    @pytest.mark.asyncio
+    async def test_request_single_ssl_error(self, monkeypatch):
+        engine = HTTPBenchmarkEngine(max_retries=0)
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                raise ssl.SSLError("certificate verify failed")
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client(url):
+            return FakeClient(), MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single("https://badssl.com")
+        assert result.status == QueryStatus.TLS_ERROR
+        assert "TLS error" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_request_single_connect_error(self, monkeypatch):
+        engine = HTTPBenchmarkEngine(max_retries=0)
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                raise httpx.ConnectError("connection refused")
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client(url):
+            return FakeClient(), MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single("https://down.example.com")
+        assert result.status == QueryStatus.CONNECTION_REFUSED
+
+    @pytest.mark.asyncio
+    async def test_run_fast_warmup(self, monkeypatch):
+        engine = HTTPBenchmarkEngine()
+        original_method = engine.method  # 'GET'
+
+        async def fake_request_single(target, iteration=0):
+            return HTTPResult(
+                target=target,
+                method=engine.method,  # capture the engine's method at call time
+                start_time=0,
+                end_time=0.01,
+                total_ms=10,
+                status=QueryStatus.SUCCESS,
+                iteration=0,
+            )
+
+        monkeypatch.setattr(engine, "request_single", fake_request_single)
+        results = await engine._run_fast_warmup(["https://a.com"])
+        assert len(results) == 1
+        # The result should reflect the method used during the call (HEAD)
+        assert results[0].method == "HEAD"
+        # After warmup, the engine's method is restored
+        assert engine.method == original_method
+
+    @pytest.mark.asyncio
+    async def test_run_benchmark(self, monkeypatch):
+        engine = HTTPBenchmarkEngine()
+
+        async def fake_request_single(target, iteration=1):
+            return HTTPResult(
+                target=target,
+                method="GET",
+                start_time=0,
+                end_time=0.01,
+                total_ms=10,
+                status=QueryStatus.SUCCESS,
+                iteration=iteration,
+            )
+
+        monkeypatch.setattr(engine, "request_single", fake_request_single)
+        results = await engine.run_benchmark(
+            ["https://a.com", "https://b.com"],
+            iterations=2,
+            warmup_fast=True,
+        )
+        # 2 targets × 2 iterations = 4 results (warmup not returned)
+        assert len(results) == 4
+        # Also check that warmup did run (failed_targets cleared, query_counter reset)
+        # The fake_request_single doesn't use progress, so no further checks needed.
+
+
+class TestTimingNetworkStream:
+    @pytest.mark.asyncio
+    async def test_start_tls_captures_timing_and_cert(self):
+        """start_tls should record TLS handshake time and optionally cert bytes."""
+        inner = MagicMock(spec=AsyncNetworkStream)
+        tls_stream = MagicMock(spec=AsyncNetworkStream)
+        ssl_obj = MagicMock()
+        ssl_obj.getpeercert.return_value = b"fake-der"
+        tls_stream.get_extra_info.return_value = ssl_obj
+        inner.start_tls = AsyncMock(return_value=tls_stream)
+
+        stream = TimingNetworkStream(inner, {})
+        result = await stream.start_tls(MagicMock(), "example.com")
+
+        assert result is not None
+        assert isinstance(result, TimingNetworkStream)
+        assert stream._metrics["tls_handshake_ms"] > 0
+        assert stream._metrics["cert_der"] == b"fake-der"
+
+    @pytest.mark.asyncio
+    async def test_transport_returns_metrics(self):
+        transport = MetricsCapturingTransport(verify=False)
+
+        # Inject metrics directly into the timing backend (what get_connection_metrics reads)
+        transport._timing_backend.metrics["tcp_connect_ms"] = 12.3
+
+        metrics = transport.get_connection_metrics()
+        assert metrics["tcp_connect_ms"] == 12.3
+
+
+class TestTimingNetworkBackend:
+    @pytest.mark.asyncio
+    async def test_connect_tcp_metrics(self):
+        """connect_tcp captures tcp_connect_ms and ip_version."""
+        backend = TimingNetworkBackend()
+        # We'll replace the backend's internal _backend with a mock that returns a mock stream
+        mock_stream = MagicMock(spec=AsyncNetworkStream)
+        mock_stream.get_extra_info.return_value = ("192.0.2.1", 443)
+        real_connect = AsyncMock(return_value=mock_stream)
+        backend._backend.connect_tcp = real_connect
+
+        stream = await backend.connect_tcp("example.com", 443, timeout=10)
+        assert isinstance(stream, TimingNetworkStream)
+        assert stream._metrics["tcp_connect_ms"] > 0
+        assert stream._metrics["ip_version"] == "IPv4"
+
+    @pytest.mark.asyncio
+    async def test_connect_tcp_ipv6(self):
+        backend = TimingNetworkBackend()
+        mock_stream = MagicMock(spec=AsyncNetworkStream)
+        mock_stream.get_extra_info.return_value = ("::1", 443, 0, 0)
+        backend._backend.connect_tcp = AsyncMock(return_value=mock_stream)
+        stream = await backend.connect_tcp("example.com", 443)
+        assert stream._metrics["ip_version"] == "IPv6"
+
+    @pytest.mark.asyncio
+    async def test_connect_tcp_no_server_addr(self):
+        backend = TimingNetworkBackend()
+        mock_stream = MagicMock(spec=AsyncNetworkStream)
+        mock_stream.get_extra_info.return_value = None
+        backend._backend.connect_tcp = AsyncMock(return_value=mock_stream)
+        stream = await backend.connect_tcp("example.com", 443)
+        assert stream._metrics["ip_version"] is None
+
+
+class TestMetricsCapturingTransport:
+
+    @pytest.mark.asyncio
+    async def test_transport_returns_metrics(self):
+        transport = MetricsCapturingTransport(verify=False)
+
+        # Inject metrics directly into the timing backend (what get_connection_metrics reads)
+        transport._timing_backend.metrics["tcp_connect_ms"] = 12.3
+
+        metrics = transport.get_connection_metrics()
+        assert metrics["tcp_connect_ms"] == 12.3
+
+    def test_transport_creates_ssl_context(self):
+        """MetricsCapturingTransport builds an SSL context."""
+        transport = MetricsCapturingTransport(verify=True)
+        assert transport._pool._ssl_context is not None
+
+    def test_transport_no_verify(self):
+        transport = MetricsCapturingTransport(verify=False)
+        assert transport._pool._ssl_context.verify_mode == ssl.CERT_NONE
+
+
+class TestParseCertDer:
+    def test_parse_valid_der(self):
+        """Generate a minimal self-signed cert and parse it."""
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "test.local")]
+        )
+        now = datetime.now(timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=30))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName("test.local")]),
+                critical=False,
+            )
+            .sign(key, hashes.SHA256(), backend=default_backend())
+        )
+        der = cert.public_bytes(serialization.Encoding.DER)
+        days, cn, issuer_cn, sans, wildcard = _parse_cert_der(der)
+        assert days >= 29
+        assert cn == "test.local"
+        assert issuer_cn == "test.local"
+        assert "test.local" in sans
+        assert not wildcard
+
+    def test_parse_invalid_der(self):
+        days, cn, issuer, sans, wildcard = _parse_cert_der(b"garbage")
+        assert days is None
+        assert cn is None

--- a/src/net_benchmark/http_bench/tests/test_exporters.py
+++ b/src/net_benchmark/http_bench/tests/test_exporters.py
@@ -1,0 +1,71 @@
+import os
+
+import pandas as pd
+
+from net_benchmark.http_bench.analysis import HTTPAnalyzer
+from net_benchmark.http_bench.exporters import (
+    HTTPCSVExporter,
+    HTTPExcelExporter,
+    HTTPExportBundle,
+)
+
+
+class TestCSVExporter:
+    def test_export_raw_results(self, tmp_path, sample_results):
+        path = tmp_path / "raw.csv"
+        HTTPCSVExporter.export_raw_results(sample_results, str(path))
+        df = pd.read_csv(path)
+        assert len(df) == len(sample_results)
+
+    def test_export_summary_statistics(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "summary.csv"
+        HTTPCSVExporter.export_summary_statistics(analyzer, str(path))
+        df = pd.read_csv(path)
+        assert len(df) == 1
+        assert "avg_dns_ms" in df.columns
+
+    def test_export_security_statistics(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "sec.csv"
+        HTTPCSVExporter.export_security_statistics(analyzer, str(path))
+        df = pd.read_csv(path)
+        assert "strict-transport-security" in df.columns
+
+    def test_export_ttfb_statistics(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "ttfb.csv"
+        HTTPCSVExporter.export_ttfb_statistics(analyzer, str(path))
+        df = pd.read_csv(path)
+        assert "avg_ttfb_ms" in df.columns
+
+
+class TestExcelExporter:
+    def test_export_results(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "report.xlsx"
+        HTTPExcelExporter.export_results(sample_results, analyzer, str(path))
+        assert os.path.exists(path)
+
+    def test_export_with_charts(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "report_charts.xlsx"
+        HTTPExcelExporter.export_results(
+            sample_results, analyzer, str(path), include_charts=True
+        )
+        assert os.path.exists(path)
+
+
+class TestJSONExport:
+    def test_export_json(self, tmp_path, sample_results):
+        analyzer = HTTPAnalyzer(sample_results)
+        path = tmp_path / "report.json"
+        HTTPExportBundle.export_json(sample_results, analyzer, str(path))
+        assert os.path.exists(path)
+        import json
+
+        with open(path) as f:
+            data = json.load(f)
+        assert "overall" in data
+        assert "target_stats" in data
+        assert "raw_results" in data

--- a/src/net_benchmark/utils/helpers.py
+++ b/src/net_benchmark/utils/helpers.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from tqdm import tqdm
+
+from net_benchmark.utils.messages import info
+
+
+def create_progress_bar(total: int, desc: str) -> Any:
+    return tqdm(
+        total=total, desc=info(desc), bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}"
+    )


### PR DESCRIPTION
- http benchmark engine: dns/tcp/tls/ttfb/ttlb timing breakdown
- security headers audit (hsts, csp, etc.) and cdn fingerprinting
- inline tls certificate capture (expiry, cn, issuer, sans)
- downgrade detection (https→http, http/2→http/1.1)
- auth: basic, bearer, custom api key, mtls, proxy, sni override
- assertions: status, body, headers, latency, content‑type, size
- cache header analysis (cache‑control, etag, last‑modified, age)
- separate timeout controls (connect, read, write)
- query parameters, body from file, auto json content‑type
- new cli commands: `benchmark`, `top`, `compare`, `monitoring`
- jitter and consistency score fix for single sample
- dns resolver ip captured on every result
- full test coverage for core, analysis, exporters, cli
- database schema for http benchmark runs and results
- documentation: readme.md expanded http section, readme.zh.md, pypi description updated