### PR TITLE
feat(http_bench): add load test engine with throughput/sustained/ramp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 # -----------------
 benchmark_results/
 monitoring_results/
+http_load_test_results/
 release.sh
 release-tag.sh
 gpg-check.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,13 @@ We welcome improvements, bug fixes, and new ideas.
 
 ---
 
+## No Paid Work or Crypto Offers
+
+This project does not accept paid proposals, crypto payments, or contracting offers inside GitHub issues or discussions.
+All contributions must be technical and open-source.
+
+---
+
 ## Community
 
 - Be respectful and constructive in discussions.

--- a/src/net_benchmark/http_bench/analysis.py
+++ b/src/net_benchmark/http_bench/analysis.py
@@ -22,6 +22,11 @@ class TargetStats:
       success_rate        ← success_rate
       min/max/avg/...     ← same latency stat fields, same formulas
       http2_rate          ← dnssec_validation_rate  (protocol quality signal)
+
+    This is also what net_benchmark.http_bench.load_test.LoadTestSummary
+    embeds for its overall and per-interval stats — one stats engine shared
+    by the regular `http benchmark` path and the `http load-test` path,
+    rather than two separate percentile implementations.
     """
 
     target: str
@@ -65,6 +70,22 @@ class TargetStats:
     cert_expiry_days_min: Optional[int] = None  # worst cert seen across requests
     alt_svc: Optional[str] = None
     ip_version: Optional[str] = None  # most common across requests
+
+    # --- 0.5.1 additions ---
+    # % of completed requests that reused an existing connection instead of
+    # opening a new one. Requires enable_connection_reuse=True on the
+    # engine; stays 0.0 otherwise.
+    connection_reuse_rate: float = 0.0
+    # % of completed requests whose TLS session ID had been seen before on
+    # this origin. Best-effort resumption signal, not a certainty — see
+    # TimingNetworkStream.start_tls in core.py.
+    tls_resumption_rate: float = 0.0
+    # Total HTTP/2 server pushes observed across all requests for this
+    # target. 0 if push detection was off or the h2 package is unavailable.
+    http2_push_total: int = 0
+    # Average multipart upload throughput (Mbps), across requests that
+    # actually uploaded (multipart_file_size > 0). 0.0 if none did.
+    avg_upload_throughput_mbps: float = 0.0
 
 
 class HTTPAnalyzer:
@@ -130,6 +151,17 @@ class HTTPAnalyzer:
                     "last_modified": r.last_modified or "",
                     "age": r.age or "",
                     "assertion_results": r.assertion_results,
+                    # --- 0.5.1 additions — previously collected on
+                    # HTTPResult but silently dropped here, so
+                    # get_target_statistics() had no way to surface them.
+                    "connection_reused": r.connection_reused,
+                    "connection_id": r.connection_id or "",
+                    "tls_resumed": r.tls_resumed,
+                    "tls_session_id": r.tls_session_id or "",
+                    "session_ticket": r.session_ticket,
+                    "http2_push_count": r.http2_push_count,
+                    "upload_throughput_mbps": r.upload_throughput_mbps,
+                    "websocket_handshake_ms": r.websocket_handshake_ms,
                 }
             )
         return pd.DataFrame(data)
@@ -261,6 +293,26 @@ class HTTPAnalyzer:
             ip_vals = td[td["ip_version"] != ""]["ip_version"]
             ip_version = str(ip_vals.mode().iloc[0]) if len(ip_vals) > 0 else None
 
+            # --- 0.5.1 additions ---
+            reused_count = int(td[td["completed"]]["connection_reused"].sum())
+            connection_reuse_rate = (
+                (reused_count / successful * 100) if successful > 0 else 0.0
+            )
+
+            resumed_count = int(td[td["completed"]]["tls_resumed"].sum())
+            tls_resumption_rate = (
+                (resumed_count / successful * 100) if successful > 0 else 0.0
+            )
+
+            http2_push_total = int(td["http2_push_count"].sum())
+
+            upload_vals = td[td["completed"] & td["upload_throughput_mbps"].notna()][
+                "upload_throughput_mbps"
+            ]
+            avg_upload_throughput_mbps = (
+                float(upload_vals.mean()) if len(upload_vals) > 0 else 0.0
+            )
+
             stats_list.append(
                 TargetStats(
                     target=target,
@@ -299,6 +351,10 @@ class HTTPAnalyzer:
                     cert_expiry_days_min=cert_min,
                     alt_svc=alt_svc,
                     ip_version=ip_version,
+                    connection_reuse_rate=connection_reuse_rate,
+                    tls_resumption_rate=tls_resumption_rate,
+                    http2_push_total=http2_push_total,
+                    avg_upload_throughput_mbps=avg_upload_throughput_mbps,
                 )
             )
 
@@ -344,6 +400,16 @@ class HTTPAnalyzer:
         )
         assertion_pass_rate = (assertion_pass_count / total * 100) if total > 0 else 0.0
 
+        # --- 0.5.1 additions ---
+        reused_count = int(self.df[self.df["completed"]]["connection_reused"].sum())
+        connection_reuse_rate = (
+            (reused_count / successful * 100) if successful > 0 else 0.0
+        )
+        resumed_count = int(self.df[self.df["completed"]]["tls_resumed"].sum())
+        tls_resumption_rate = (
+            (resumed_count / successful * 100) if successful > 0 else 0.0
+        )
+
         return {
             "total_requests": total,
             "successful_requests": successful,
@@ -360,6 +426,8 @@ class HTTPAnalyzer:
             ),
             "dns_resolver_ip": resolver_ip,
             "assertion_pass_rate": assertion_pass_rate,
+            "connection_reuse_rate": connection_reuse_rate,
+            "tls_resumption_rate": tls_resumption_rate,
         }
 
     def get_ttfb_statistics(self) -> List[Dict[str, Any]]:

--- a/src/net_benchmark/http_bench/cli.py
+++ b/src/net_benchmark/http_bench/cli.py
@@ -19,6 +19,13 @@ from net_benchmark.http_bench.exporters import (
     HTTPExportBundle,
     HTTPPDFExporter,
 )
+from net_benchmark.http_bench.load_test import LoadTestEngine, LoadTestSummary
+from net_benchmark.http_bench.load_test_exporters import (
+    LoadTestCSVExporter,
+    LoadTestExcelExporter,
+    LoadTestExportBundle,
+    LoadTestPDFExporter,
+)
 from net_benchmark.utils.helpers import create_progress_bar
 from net_benchmark.utils.messages import (
     error,
@@ -763,8 +770,6 @@ def monitoring(
                 )
 
             # ── persist snapshot ──────────────────────────────────────────────
-            import json
-
             snapshot_path = (
                 output_path
                 / f"http_monitor_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
@@ -1124,6 +1129,380 @@ def compare(
         if progress_bar:
             progress_bar.close()
         click.echo(error(f"Error during comparison: {e}"))
+        raise
+
+
+# ── load-test ──────────────────────────────────────────────────────────────
+@http.command(name="load-test")
+# --- 0.5.1: same --targets/--use-defaults pattern as `benchmark`/`compare`,
+# via TargetManager — multiple targets run concurrently (one LoadTestEngine
+# per target, fanned out with asyncio.gather).
+@click.option(
+    "--targets",
+    "-t",
+    default=None,
+    help="Comma-separated URLs or path to a text file (one URL per line).",
+)
+@click.option("--use-defaults", is_flag=True, help="Use built-in default target URLs.")
+# --- 0.5.1: mode selects which of the three load-shaping strategies runs —
+# see net_benchmark.http_bench.load_test.LoadTestEngine for the actual logic.
+@click.option(
+    "--mode",
+    type=click.Choice(["throughput", "sustained", "ramp-up"], case_sensitive=False),
+    default="throughput",
+    show_default=True,
+    help="Load test mode: throughput (saturate), sustained (fixed rate), "
+    "ramp-up (gradually increase concurrency).",
+)
+@click.option(
+    "--duration",
+    default=10.0,
+    show_default=True,
+    help="Duration in seconds (throughput/sustained modes).",
+)
+@click.option(
+    "--rps",
+    type=float,
+    default=None,
+    help="Target requests/sec — required for --mode sustained.",
+)
+@click.option(
+    "--max-concurrency",
+    default=200,
+    show_default=True,
+    help="Max in-flight concurrent requests (throughput mode).",
+)
+@click.option(
+    "--start-concurrency",
+    default=10,
+    show_default=True,
+    help="Starting concurrency (ramp-up mode).",
+)
+@click.option(
+    "--ramp-concurrency",
+    default=200,
+    show_default=True,
+    help="Peak concurrency to ramp up to (ramp-up mode).",
+)
+@click.option(
+    "--ramp-duration",
+    default=30.0,
+    show_default=True,
+    help="Seconds spent ramping up to peak concurrency (ramp-up mode).",
+)
+@click.option(
+    "--max-total-rps",
+    type=float,
+    default=None,
+    help="Safety ceiling on aggregate requests/sec during ramp-up (default: "
+    "ramp-concurrency * 50). Not a target rate — use --mode sustained for "
+    "that. Only matters against very fast targets where request latency "
+    "alone wouldn't otherwise bound throughput.",
+)
+@click.option(
+    "--hold-duration",
+    default=10.0,
+    show_default=True,
+    help="Seconds to hold at peak concurrency after ramping (ramp-up mode).",
+)
+@click.option("--method", "-m", default="GET", show_default=True, help="HTTP method.")
+@click.option(
+    "--headers",
+    default=None,
+    help='Extra request headers as "Key:Value,Key:Value".',
+)
+@click.option(
+    "--timeout", default=10.0, show_default=True, help="Request timeout in seconds."
+)
+@click.option("--no-http2", is_flag=True, help="Disable HTTP/2 (force HTTP/1.1).")
+@click.option(
+    "--no-verify-ssl", is_flag=True, help="Skip TLS certificate verification."
+)
+# --- 0.5.1: these three toggle the correctness-sensitive/best-effort
+# detection features added in core.py — off by default since they add
+# per-request overhead (extra dict lookups, session-id bookkeeping) that
+# isn't worth paying for on a pure throughput/sustained run unless the
+# person actually wants the data.
+@click.option(
+    "--enable-connection-reuse",
+    is_flag=True,
+    help="Track keep-alive / connection reuse rate (item 4).",
+)
+@click.option(
+    "--enable-tls-resumption",
+    is_flag=True,
+    help="Best-effort TLS session resumption detection (item 6) — "
+    "heuristic based on repeated session IDs, not a certainty.",
+)
+@click.option(
+    "--enable-push-detection",
+    is_flag=True,
+    help="Best-effort HTTP/2 server push detection (item 8) — requires the "
+    "optional 'h2' package; silently reports zero pushes if unavailable.",
+)
+@click.option(
+    "--output",
+    "-o",
+    default="./http_load_test_results",
+    show_default=True,
+    help="Output directory for results.",
+)
+@click.option(
+    "--formats",
+    "-f",
+    default="csv,excel",
+    show_default=True,
+    help="Output formats (csv, excel, pdf, json).",
+)
+@click.option(
+    "--include-charts", is_flag=True, help="Include charts in Excel and PDF exports."
+)
+@click.option("--quiet", is_flag=True, help="Suppress progress output.")
+def load_test(
+    targets: Optional[str],
+    use_defaults: bool,
+    mode: str,
+    duration: float,
+    rps: Optional[float],
+    max_concurrency: int,
+    start_concurrency: int,
+    ramp_concurrency: int,
+    ramp_duration: float,
+    hold_duration: float,
+    max_total_rps: Optional[float],
+    method: str,
+    headers: Optional[str],
+    timeout: float,
+    no_http2: bool,
+    no_verify_ssl: bool,
+    enable_connection_reuse: bool,
+    enable_tls_resumption: bool,
+    enable_push_detection: bool,
+    output: str,
+    formats: str,
+    include_charts: bool,
+    quiet: bool,
+) -> None:
+    """Run a load test against one or more targets — throughput, sustained
+    rate, or ramp-up (0.5.1). Multiple targets run concurrently.
+
+    Examples:
+        net-benchmark http load-test -t https://example.com --mode throughput --duration 15
+        net-benchmark http load-test -t a.com,b.com --mode sustained --rps 50 --duration 30
+        net-benchmark http load-test --use-defaults --mode ramp-up \\
+            --start-concurrency 5 --ramp-concurrency 100 --ramp-duration 20 --hold-duration 10
+    """
+    if not use_defaults and not targets:
+        click.echo(error("Provide --targets or use --use-defaults."))
+        return
+
+    try:
+        target_list = (
+            TargetManager.get_default_targets()
+            if use_defaults
+            else TargetManager.parse_targets_input(targets).targets
+        )
+    except Exception as e:
+        click.echo(error(f"Error loading targets: {e}"))
+        return
+
+    # --- 0.5.1: normalize each target the same way `compare` does, so bare
+    # hostnames work without forcing the person to type https://.
+    target_list = [
+        t if t.startswith(("http://", "https://")) else "https://" + t
+        for t in (t.strip() for t in target_list)
+    ]
+
+    mode_normalized = mode.lower().replace("-", "_")  # "ramp-up" -> "ramp_up"
+
+    if mode_normalized == "sustained" and not rps:
+        click.echo(error("--mode sustained requires --rps."))
+        return
+
+    output_formats = [f.strip().lower() for f in formats.split(",")]
+    for fmt in output_formats:
+        if fmt not in ("csv", "excel", "pdf", "json"):
+            click.echo(
+                error(f"Invalid format '{fmt}'. Must be csv, excel, pdf, or json.")
+            )
+            return
+
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    extra_headers: Dict[str, str] = {}
+    if headers:
+        for pair in headers.split(","):
+            if ":" in pair:
+                k, _, v = pair.partition(":")
+                extra_headers[k.strip()] = v.strip()
+
+    if not quiet:
+        click.echo(info("Configuration:"))
+        click.echo(info(f"  Targets:      {len(target_list)}"))
+        click.echo(info(f"  Mode:         {mode_normalized}"))
+        if mode_normalized == "throughput":
+            click.echo(info(f"  Duration:     {duration}s"))
+            click.echo(info(f"  Max conc.:    {max_concurrency}"))
+        elif mode_normalized == "sustained":
+            click.echo(info(f"  Duration:     {duration}s"))
+            click.echo(info(f"  Target RPS:   {rps}"))
+        else:  # ramp_up
+            click.echo(
+                info(f"  Concurrency:  {start_concurrency} -> {ramp_concurrency}")
+            )
+            click.echo(info(f"  Ramp:         {ramp_duration}s, hold {hold_duration}s"))
+            if max_total_rps:
+                click.echo(info(f"  Max total RPS ceiling: {max_total_rps}"))
+        click.echo(
+            info(
+                f"  Connection reuse tracking: {'on' if enable_connection_reuse else 'off'}"
+            )
+        )
+        click.echo(
+            info(
+                f"  TLS resumption detection:  {'on' if enable_tls_resumption else 'off'}"
+            )
+        )
+        click.echo(
+            info(
+                f"  HTTP/2 push detection:     {'on' if enable_push_detection else 'off'}"
+            )
+        )
+        click.echo(warning(f"Starting load test ({mode_normalized})…"))
+
+    start_wall = time.time()
+
+    try:
+        # --- 0.5.1: one HTTPBenchmarkEngine + LoadTestEngine per target
+        # (each origin gets its own connection pool, per core.py's design),
+        # all run concurrently via asyncio.gather.
+        async def _run_one(t: str) -> "LoadTestSummary":
+            http_engine = HTTPBenchmarkEngine(
+                max_concurrent=max(max_concurrency, ramp_concurrency, 50),
+                timeout=timeout,
+                method=method.upper(),
+                headers=extra_headers,
+                http2=not no_http2,
+                verify_ssl=not no_verify_ssl,
+                enable_connection_reuse=enable_connection_reuse,
+                enable_tls_resumption=enable_tls_resumption,
+                enable_push_detection=enable_push_detection,
+            )
+            load_engine = LoadTestEngine(t, http_engine=http_engine)
+            if mode_normalized == "throughput":
+                s = await load_engine.run_throughput(
+                    duration_s=duration, max_concurrency=max_concurrency
+                )
+            elif mode_normalized == "sustained":
+                # type narrowing: we already validated that --rps is present when
+                # mode == "sustained" (see the check above), so mypy would otherwise
+                # complain that `rps` might be None.  The assertion removes that
+                # ambiguity at static‑analysis level and also acts as a safety net
+                # in case someone later moves the validation without adjusting this path.
+                assert rps is not None, "rps must be set for sustained mode"
+                s = await load_engine.run_sustained(target_rps=rps, duration_s=duration)
+            else:  # ramp_up
+                s = await load_engine.run_ramp_up(
+                    start_concurrency=start_concurrency,
+                    max_concurrency=ramp_concurrency,
+                    ramp_duration_s=ramp_duration,
+                    hold_duration_s=hold_duration,
+                    max_total_rps=max_total_rps,
+                )
+            await load_engine.close()
+            return s
+
+        async def _run_all() -> List["LoadTestSummary"]:
+            return await asyncio.gather(*(_run_one(t) for t in target_list))
+
+        summaries = list(asyncio.run(_run_all()))
+
+        wall_elapsed = time.time() - start_wall
+        if not quiet:
+            click.echo(success(f"Load test completed in {wall_elapsed:.2f}s"))
+            # --- 0.5.1: summary.stats is a TargetStats (net_benchmark.http_bench.analysis)
+            # — same stats engine as `http benchmark`. success_rate and
+            # connection_reuse_rate are already 0-100 (percentages); TargetStats
+            # has no p50/p90 fields — median_latency is the p50 equivalent.
+            for summary in summaries:
+                summary_lines = [
+                    f"Target:           {summary.target}",
+                    f"Mode:             {summary.mode.value}",
+                    f"Total requests:   {summary.stats.total_requests}",
+                    f"Successful:       {summary.stats.successful_requests} ({summary.stats.success_rate:.2f}%)",
+                    f"Achieved RPS:     {summary.achieved_rps:.1f}",
+                ]
+                if summary.target_rps:
+                    summary_lines.append(f"Target RPS:       {summary.target_rps:.1f}")
+                summary_lines += [
+                    f"Median latency:   {summary.stats.median_latency:.1f} ms",
+                    f"P95 latency:      {summary.stats.p95_latency:.1f} ms",
+                    f"P99 latency:      {summary.stats.p99_latency:.1f} ms",
+                    f"Connections open: {summary.connection_reuse.connections_opened}",
+                ]
+                if enable_connection_reuse:
+                    summary_lines.append(
+                        f"Reuse rate:       {summary.connection_reuse.reuse_rate * 100:.1f}%"
+                    )
+                if enable_tls_resumption:
+                    summary_lines.append(
+                        f"TLS resumption:   {summary.stats.tls_resumption_rate:.1f}%"
+                    )
+                click.echo(summary_box(summary_lines))
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base_name = f"net_benchmark.load_test_{mode_normalized}_{timestamp}"
+
+        if not quiet:
+            click.echo(warning("Exporting results…"))
+
+        if "csv" in output_formats:
+            LoadTestCSVExporter.export_raw_results(
+                summaries, str(output_path / f"{base_name}_raw.csv")
+            )
+            LoadTestCSVExporter.export_summary(
+                summaries, str(output_path / f"{base_name}_summary.csv")
+            )
+            LoadTestCSVExporter.export_intervals(
+                summaries, str(output_path / f"{base_name}_timeline.csv")
+            )
+            LoadTestCSVExporter.export_error_breakdown(
+                summaries, str(output_path / f"{base_name}_errors.csv")
+            )
+
+        if "excel" in output_formats:
+            LoadTestExcelExporter.export_results(
+                summaries,
+                str(output_path / f"{base_name}.xlsx"),
+                include_charts=include_charts,
+            )
+
+        if "pdf" in output_formats:
+            try:
+                LoadTestPDFExporter.export_results(
+                    summaries,
+                    str(output_path / f"{base_name}.pdf"),
+                    include_charts=include_charts,
+                )
+            except Exception as e:
+                click.echo(error(f"PDF export failed: {e}"))
+
+        if "json" in output_formats:
+            LoadTestExportBundle.export_json(
+                summaries, str(output_path / f"{base_name}.json")
+            )
+
+        if not quiet:
+            click.echo(success("All exports completed!"))
+            click.echo(info(f"Results saved to: {output_path}"))
+
+    except click.UsageError:
+        raise
+    except KeyboardInterrupt:
+        click.echo(warning("\nLoad test interrupted by user"))
+    except Exception as e:
+        click.echo(error(f"Load test error: {e}"))
         raise
 
 

--- a/src/net_benchmark/http_bench/core.py
+++ b/src/net_benchmark/http_bench/core.py
@@ -1,7 +1,10 @@
 """Core HTTP benchmarking functionality."""
 
 import asyncio
+import hashlib
 import ipaddress
+import os
+import re
 import ssl
 import time
 import uuid
@@ -10,7 +13,19 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 import httpcore
@@ -24,6 +39,22 @@ from httpcore._backends.base import (
     AsyncNetworkStream,
 )
 
+# WebSocket dependency (optional)
+try:
+    import aiohttp
+
+    _AIOHTTP_AVAILABLE = True
+except ImportError:
+    _AIOHTTP_AVAILABLE = False
+
+try:
+    import h2.connection
+    import h2.events
+
+    _H2_AVAILABLE = True
+except ImportError:
+    _H2_AVAILABLE = False
+
 from net_benchmark.dns_benchmark.core import QueryStatus
 from net_benchmark.utils.messages import warning
 
@@ -33,15 +64,28 @@ from net_benchmark.utils.messages import warning
 
 
 class TimingNetworkStream(AsyncNetworkStream):
-    """Wraps an AsyncNetworkStream to capture TCP-connect and TLS-handshake times.
+    """Wraps an AsyncNetworkStream to capture TCP-connect and TLS-handshake
+    times for exactly *this* connection.
 
-    The metrics dict is shared with TimingNetworkBackend so writes made inside
-    start_tls() are immediately visible there without any extra plumbing.
+    # Each TimingNetworkStream owns its own `metrics` dict
+    (created fresh in TimingNetworkBackend.connect_tcp — never shared/mutated
+    by other connections). Callers that need this specific connection's
+    metrics should retrieve this stream instance (e.g. via
+    httpx.Response.extensions["network_stream"]) and call get_metrics(),
+    rather than reading TimingNetworkBackend.metrics, which only reflects
+    whichever connection was opened *most recently* on this backend and is
+    unsafe to read under concurrency (see MetricsCapturingTransport docs).
     """
 
-    def __init__(self, stream: AsyncNetworkStream, metrics: Dict[str, Any]) -> None:
+    def __init__(
+        self,
+        stream: AsyncNetworkStream,
+        metrics: Dict[str, Any],
+        session_registry: Optional[Set[bytes]] = None,
+    ) -> None:
         self._stream = stream
-        self._metrics = metrics  # shared reference — intentional
+        self._metrics = metrics  # per-connection — intentional
+        self._session_registry = session_registry
 
     async def read(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
         return await self._stream.read(max_bytes, timeout)
@@ -61,30 +105,94 @@ class TimingNetworkStream(AsyncNetworkStream):
         tls_start = time.perf_counter()
         tls_stream = await self._stream.start_tls(ssl_context, server_hostname, timeout)
         self._metrics["tls_handshake_ms"] = (time.perf_counter() - tls_start) * 1000
+
+        # TLS certificate capture + best-effort resumption detection.
         try:
             ssl_obj = tls_stream.get_extra_info("ssl_object")
             if ssl_obj is not None:
                 self._metrics["cert_der"] = ssl_obj.getpeercert(binary_form=True)
+
+                # Session ticket presence
+                session = getattr(ssl_obj, "session", None)
+                session_id: Optional[bytes] = None
+                if session is not None:
+                    session_id = session.id
+                    self._metrics["tls_session_id"] = (
+                        session_id.hex() if session_id else None
+                    )
+
+                    ticket_hint = getattr(session, "ticket_lifetime_hint", None)
+                    self._metrics["session_ticket"] = (
+                        ticket_hint is not None and ticket_hint > 0
+                    )
+                else:
+                    self._metrics["tls_session_id"] = None
+                    self._metrics["session_ticket"] = False
+
+                # Resumption detection. Python's stdlib
+                # ssl.SSLSession has no reliable "was this handshake resumed"
+                # flag (there is no cross-version `session.reused` attribute —
+                # a previous version of this code assumed one existed; it did
+                # not, and always evaluated to False). The best signal
+                # available without raw packet inspection is whether the same
+                # TLS session ID has been seen before on a *new* TCP
+                # connection to this origin. This is a best-effort heuristic,
+                # not a certainty (session tickets in TLS 1.3 can rotate IDs
+                # even on a resumed handshake) — treat tls_resumed accordingly.
+                if session_id and self._session_registry is not None:
+                    self._metrics["tls_resumed"] = session_id in self._session_registry
+                    self._session_registry.add(session_id)
+                else:
+                    self._metrics["tls_resumed"] = False
         except Exception:
-            pass
-        # Wrap the TLS stream so further calls keep the same metrics reference
-        return TimingNetworkStream(tls_stream, self._metrics)
+            self._metrics["tls_resumed"] = False
+            self._metrics["session_ticket"] = False
+
+        # Wrap the TLS stream so further calls keep the same per-connection
+        # metrics dict and session registry reference.
+        return TimingNetworkStream(tls_stream, self._metrics, self._session_registry)
 
     def get_extra_info(self, info: str) -> Any:
         return self._stream.get_extra_info(info)
 
+    # Safe per-connection accessor (see class docstring)
+    def get_metrics(self) -> Dict[str, Any]:
+        """This connection's own metrics dict — safe to read even when other
+        connections are concurrently in flight on the same backend.
+        """
+        return self._metrics
+
 
 class TimingNetworkBackend(AsyncNetworkBackend):
-    """Wraps AutoBackend to inject per-connection TCP and TLS timing.
+    """
+    Wraps AutoBackend to inject per-connection TCP and TLS timing.
 
-    One backend instance per origin so metrics are not clobbered across origins.
+    One backend instance per origin. `self.metrics` reflects only the most
+    recently *opened* connection and is kept for backward compatibility with
+    MetricsCapturingTransport.get_connection_metrics() (used as a fallback
+    when the per-request stream isn't retrievable) — callers that need
+    correct per-request attribution under concurrency should prefer the
+    per-stream metrics via TimingNetworkStream.get_metrics().
     """
 
     def __init__(self, local_address: Optional[str] = None) -> None:
         self._backend = AutoBackend()
         self.local_address = local_address
-        # Overwritten on every new connection — safe: asyncio is single-threaded.
         self.metrics: Dict[str, Any] = {}
+        # Cumulative — NOT reset per-connection. Used for
+        # connection-reuse rate calculation (load_test.py) via
+        # connections_opened vs total requests served.
+        self.connections_opened: int = 0
+        # Metrics keyed by connection_id, so callers with no
+        # response object (e.g. get_connection_stats) can ask for a specific
+        # connection's metrics instead of "whatever opened most recently".
+        self.metrics_by_id: Dict[str, Dict[str, Any]] = {}
+        # TLS session IDs seen on this origin, across all
+        # connections for this backend's lifetime — used for best-effort
+        # resumption detection. Shared by reference into every
+        # TimingNetworkStream this backend creates (safe: asyncio is
+        # single-threaded).
+        self.seen_tls_session_ids: Set[bytes] = set()
 
     async def connect_tcp(
         self,
@@ -94,7 +202,6 @@ class TimingNetworkBackend(AsyncNetworkBackend):
         local_address: Optional[str] = None,
         socket_options: Optional[Iterable[SOCKET_OPTION]] = None,
     ) -> AsyncNetworkStream:
-
         if local_address is None:
             local_address = self.local_address
 
@@ -106,21 +213,39 @@ class TimingNetworkBackend(AsyncNetworkBackend):
             local_address=local_address,
             socket_options=socket_options,
         )
-        self.metrics = {
+        self.connections_opened += 1
+        # A fresh dict per connection (not a mutated shared
+        # one) — this object, not self.metrics, is what TimingNetworkStream
+        # writes into and what request_single should read back for this
+        # specific connection (see _get_connection_metrics_for_response).
+        conn_metrics: Dict[str, Any] = {
             "tcp_connect_ms": (time.perf_counter() - tcp_start) * 1000,
             "tls_handshake_ms": None,
             "cert_der": None,
             "ip_version": None,
+            "connection_id": f"conn-{self.connections_opened}",
+            # TCP Fast Open cannot be reliably detected from
+            # Python's socket/ssl stack without raw packet inspection (there
+            # is no portable "was TFO actually used on this handshake" signal
+            # — ssl.TCP_FASTOPEN only indicates platform *support* for the
+            # socket option, not that this connection used it). Rather than
+            # report a fabricated guess, this is left as None (unknown).
+            "tcp_fast_open": None,
         }
+
         try:
             server_addr = stream.get_extra_info("server_addr")
             if isinstance(server_addr, tuple) and server_addr:
-                self.metrics["ip_version"] = (
+                conn_metrics["ip_version"] = (
                     f"IPv{ipaddress.ip_address(server_addr[0]).version}"
                 )
         except Exception:
             pass
-        return TimingNetworkStream(stream, self.metrics)
+
+        self.metrics = conn_metrics  # last-connection snapshot (fallback path)
+        # --- 0.5.1: fix — also index by connection_id for safe lookup
+        self.metrics_by_id[conn_metrics["connection_id"]] = conn_metrics
+        return TimingNetworkStream(stream, conn_metrics, self.seen_tls_session_ids)
 
     async def connect_unix_socket(
         self,
@@ -137,16 +262,84 @@ class TimingNetworkBackend(AsyncNetworkBackend):
 
 
 # ---------------------------------------------------------------------------
+# HTTP/2 push detection pool — best-effort, optional dependency.
+# ---------------------------------------------------------------------------
+if _H2_AVAILABLE:
+
+    class PushTrackingH2Connection(h2.connection.H2Connection):
+        """An H2 connection that records promised stream headers."""
+
+        def __init__(self, config: Any = None) -> None:
+            super().__init__(config)
+            self.push_promises: List[Dict[str, Any]] = []
+
+        def receive_data(self, data: bytes) -> List["h2.events.Event"]:
+            events = super().receive_data(data)
+            for event in events:
+                if isinstance(event, h2.events.PushedStreamReceived):
+                    headers: Dict[bytes, bytes] = {
+                        bytes(k): bytes(v) for k, v in (event.headers or [])
+                    }
+                    path = headers.get(b":path", b"").decode()
+                    scheme = headers.get(b":scheme", b"https").decode()
+                    authority = headers.get(b":authority", b"").decode()
+                    url = (
+                        f"{scheme}://{authority}{path}" if authority and path else path
+                    )
+                    self.push_promises.append(
+                        {
+                            "stream_id": event.parent_stream_id,
+                            "promised_stream_id": event.pushed_stream_id,
+                            "url": url,
+                        }
+                    )
+            return events
+
+    class PushDetectingPool(httpcore.AsyncConnectionPool):
+        """AsyncConnectionPool that injects push-tracking H2 connections.
+
+        This relies on httpcore private internals (_init_connection,
+        _h2_connection) that are not part of httpcore's public API and are
+        not guaranteed stable across versions. If either is missing or
+        raises, push detection silently degrades to "no pushes recorded"
+        rather than crashing the request — see _init_connection below.
+        """
+
+        async def _init_connection(self, url: Any, ssl_context: ssl.SSLContext) -> Any:
+            conn = await super()._init_connection(url, ssl_context)  # type: ignore[misc]
+            try:
+                http_conn = conn.connection
+                if hasattr(http_conn, "_h2_connection"):
+                    config = http_conn._h2_connection.config
+                    http_conn._h2_connection = PushTrackingH2Connection(config)
+            except Exception:
+                # Private-API shape changed underneath us — degrade
+                # gracefully rather than break the whole request.
+                pass
+            return conn
+
+else:
+    PushTrackingH2Connection = None  # type: ignore[assignment,misc]
+    PushDetectingPool = None  # type: ignore[assignment,misc]
+
+
+# ---------------------------------------------------------------------------
 # Transport — build httpcore pool directly to avoid overriding _init_pool
 # ---------------------------------------------------------------------------
 
 
 class MetricsCapturingTransport(httpx.AsyncHTTPTransport):
-    """AsyncHTTPTransport that captures per-connection timing and TLS metrics.
+    """AsyncHTTPTransport that captures per-connection timing, TLS metrics,
+    connection reuse info, and (best-effort) HTTP/2 pushes.
 
-    Rather than overriding the non-existent _init_pool hook, we build the
-    httpcore.AsyncConnectionPool ourselves and pass the custom TimingNetworkBackend
-    directly.
+    # get_connection_metrics() returns only the
+    most-recently-opened connection's metrics for this transport and is
+    unsafe to rely on when multiple requests to the same origin are in
+    flight concurrently — it exists as a fallback for callers that can't
+    retrieve the per-request stream (e.g. sequential/single-concurrency use,
+    or older code). Prefer reading
+    httpx.Response.extensions["network_stream"].get_metrics() when
+    available; request_single() below does this automatically.
     """
 
     def __init__(
@@ -158,6 +351,7 @@ class MetricsCapturingTransport(httpx.AsyncHTTPTransport):
         mtls_cert: Optional[str] = None,
         mtls_key: Optional[str] = None,
         local_address: Optional[str] = None,
+        enable_push_detection: bool = False,
     ) -> None:
         # Build SSL context manually so we control mTLS and verification.
         ssl_context = ssl.create_default_context()
@@ -172,17 +366,63 @@ class MetricsCapturingTransport(httpx.AsyncHTTPTransport):
         self._timing_backend = TimingNetworkBackend(local_address=local_address)
         self._sni_hostname = sni_hostname
 
-        # Inject our backend directly into httpcore's pool.  httpx's
-        # handle_async_request delegates to self._pool, so this is sufficient.
-        self._pool = httpcore.AsyncConnectionPool(
+        # Push detection needs both the h2 package and
+        # PushDetectingPool's httpcore-internals hook to be usable. If either
+        # is unavailable, fall back to the plain pool rather than raising —
+        # the caller asked for a benchmark, not for h2 to be a hard dependency.
+        use_push_pool = (
+            enable_push_detection and _H2_AVAILABLE and PushDetectingPool is not None
+        )
+        self._enable_push_detection = use_push_pool
+
+        pool_cls = PushDetectingPool if use_push_pool else httpcore.AsyncConnectionPool
+        self._pool: httpcore.AsyncConnectionPool = pool_cls(
             ssl_context=ssl_context,
             http2=http2,
             network_backend=self._timing_backend,
         )
 
-    def get_connection_metrics(self) -> Dict[str, Any]:
-        """Return a snapshot of metrics from the most recently established connection."""
+    def get_connection_metrics(
+        self, connection_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Pass connection_id to get that specific
+        connection's metrics safely, even under concurrency (looked up from
+        TimingNetworkBackend.metrics_by_id, unaffected by other connections
+        opening/closing). Without connection_id, falls back to the old
+        "most recently opened" snapshot — still unsafe under concurrency,
+        kept only for callers with no id to give (e.g. a totally fresh
+        transport with zero requests sent).
+        """
+        if connection_id is not None:
+            return dict(self._timing_backend.metrics_by_id.get(connection_id, {}))
         return dict(self._timing_backend.metrics)
+
+    # Connection-reuse rate calculation
+    def get_connections_opened(self) -> int:
+        """Cumulative count of new TCP connections opened by this transport's pool."""
+        return self._timing_backend.connections_opened
+
+    # HTTP/2 push detection
+    def get_recent_push_promises(self) -> List[Dict[str, Any]]:
+        """Return any HTTP/2 push promises recorded by the push-detecting
+        pool. Empty list if push detection is unavailable/disabled, or if
+        the httpcore internals it depends on aren't present in this
+        version — never raises for that reason. Only AttributeError is
+        swallowed here (private-API shape drift); anything else propagates
+        so real bugs in this loop aren't hidden alongside "h2 unavailable".
+        """
+        if not self._enable_push_detection:
+            return []
+        try:
+            for conn in self._pool.connections:
+                http_conn = conn.connection  # type: ignore[attr-defined]
+                if hasattr(http_conn, "_h2_connection") and isinstance(
+                    http_conn._h2_connection, PushTrackingH2Connection
+                ):
+                    return http_conn._h2_connection.push_promises
+        except AttributeError:
+            pass
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +544,112 @@ CDN_VALUE_PATTERNS: Dict[str, Dict[str, str]] = {
 }
 
 
+class HTTPDigestAuth(httpx.Auth):
+    """httpx-native Digest authentication (MD5 or SHA-256, qop=auth).
+
+    Replaces a previous version that borrowed
+    requests.auth.HTTPDigestAuth outside its intended Session.send() retry
+    flow (it never actually computed a digest response from the real
+    WWW-Authenticate challenge). This parses the real 401 and computes
+    HA1/HA2/response directly, no `requests` dependency.
+    """
+
+    _CHALLENGE_RE = re.compile(r'(\w+)=(?:"([^"]*)"|([^,\s]*))')
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+        self._nonce_count = 0
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        response = yield request
+        if response.status_code != 401:
+            return
+
+        www_auth = response.headers.get("www-authenticate", "")
+        if not www_auth.lower().startswith("digest"):
+            return
+
+        challenge = self._parse_challenge(www_auth)
+        if not challenge.get("nonce"):
+            return
+
+        auth_header = self._build_header(request, challenge)
+        if auth_header:
+            request.headers["Authorization"] = auth_header
+            yield request
+
+    @classmethod
+    def _parse_challenge(cls, header_value: str) -> Dict[str, str]:
+        body = (
+            header_value[len("Digest ") :]
+            if header_value.lower().startswith("digest ")
+            else header_value
+        )
+        params: Dict[str, str] = {}
+        for match in cls._CHALLENGE_RE.finditer(body):
+            key = match.group(1)
+            value = match.group(2) if match.group(2) is not None else match.group(3)
+            params[key] = (value or "").strip()
+        return params
+
+    def _build_header(
+        self, request: httpx.Request, challenge: Dict[str, str]
+    ) -> Optional[str]:
+        realm = challenge.get("realm", "")
+        nonce = challenge.get("nonce", "")
+        opaque = challenge.get("opaque")
+        qop_offered = challenge.get("qop", "")
+        use_qop = (
+            "auth" in [q.strip() for q in qop_offered.split(",")]
+            if qop_offered
+            else False
+        )
+        algorithm = challenge.get("algorithm", "MD5").upper()
+        hash_func = hashlib.sha256 if algorithm.startswith("SHA-256") else hashlib.md5
+
+        def h(data: str) -> str:
+            return hash_func(data.encode("utf-8")).hexdigest()
+
+        uri = (
+            request.url.raw_path.decode()
+            if hasattr(request.url, "raw_path")
+            else str(request.url)
+        )
+        method = request.method
+
+        ha1 = h(f"{self.username}:{realm}:{self.password}")
+        ha2 = h(f"{method}:{uri}")
+
+        header_parts = [
+            f'username="{self.username}"',
+            f'realm="{realm}"',
+            f'nonce="{nonce}"',
+            f'uri="{uri}"',
+            f"algorithm={algorithm}",
+        ]
+
+        if use_qop:
+            self._nonce_count += 1
+            nc = f"{self._nonce_count:08x}"
+            cnonce = uuid.uuid4().hex[:16]
+            response_digest = h(f"{ha1}:{nonce}:{nc}:{cnonce}:auth:{ha2}")
+            header_parts.append(f'response="{response_digest}"')
+            header_parts.append("qop=auth")
+            header_parts.append(f"nc={nc}")
+            header_parts.append(f'cnonce="{cnonce}"')
+        else:
+            response_digest = h(f"{ha1}:{nonce}:{ha2}")
+            header_parts.append(f'response="{response_digest}"')
+
+        if opaque:
+            header_parts.append(f'opaque="{opaque}"')
+
+        return "Digest " + ", ".join(header_parts)
+
+
 @dataclass
 class HTTPResult:
     """Result of a single HTTP request"""
@@ -365,6 +711,28 @@ class HTTPResult:
     request_id: Optional[str] = None
     # assertions
     assertion_results: Dict[str, bool] = field(default_factory=dict)
+
+    # --- 0.5.1 fields ---
+    connection_id: Optional[str] = None
+    connection_reused: bool = False
+    # Always None: Python's socket/ssl stack cannot reliably confirm TFO
+    # usage without raw packet inspection. Kept as a field (rather than
+    # removed) so downstream code/exporters don't break; see
+    # TimingNetworkBackend.connect_tcp for the full explanation.
+    tcp_fast_open: Optional[bool] = None
+    # Best-effort: same TLS session ID seen on a prior connection to this
+    # origin. Not a certainty — see TimingNetworkStream.start_tls.
+    tls_resumed: bool = False
+    tls_session_id: Optional[str] = None
+    session_ticket: bool = False
+    # Best-effort: depends on httpcore private internals; empty if the h2
+    # package isn't installed or those internals are unavailable.
+    http2_push_count: int = 0
+    http2_pushes: List[str] = field(default_factory=list)
+    upload_size_bytes: Optional[int] = None
+    upload_time_ms: Optional[float] = None
+    upload_throughput_mbps: Optional[float] = None
+    websocket_handshake_ms: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         d = asdict(self)
@@ -484,6 +852,14 @@ class HTTPBenchmarkEngine:
         query_params: Optional[Dict[str, str]] = None,
         body: Optional[bytes] = None,
         local_address: Optional[str] = None,
+        # --- 0.5.1: new feature toggles (all default False/off — zero
+        # behavior change for existing callers unless explicitly opted in)
+        use_cookie_jar: bool = False,
+        enable_push_detection: bool = False,
+        enable_connection_reuse: bool = False,
+        enable_tfo_detection: bool = False,
+        enable_tls_resumption: bool = False,
+        enable_session_ticket: bool = False,
     ) -> None:
         self.max_concurrent = max_concurrent
         self.max_retries = max_retries
@@ -514,6 +890,19 @@ class HTTPBenchmarkEngine:
         self._transports: Dict[str, MetricsCapturingTransport] = {}
         self._dns_cache: Dict[str, Tuple[float, str]] = {}
         self.dns_resolver_ip = self._detect_dns_resolver()
+
+        # --- 0.5.1: feature toggle storage
+        self.use_cookie_jar = use_cookie_jar
+        self.enable_push_detection = enable_push_detection
+        self.enable_connection_reuse = enable_connection_reuse
+        self.enable_tfo_detection = enable_tfo_detection
+        self.enable_tls_resumption = enable_tls_resumption
+        self.enable_session_ticket = enable_session_ticket
+
+        # --- 0.5.1: fix — origin -> set of connection_ids already seen
+        # (must be a set, not a single last-id string, since with
+        # concurrency the "most recent" id is not well-defined).
+        self._last_connection_id: Dict[str, Set[str]] = {}
 
         # Build timeout object — may be a plain float or an httpx.Timeout
         if connect_timeout or read_timeout or write_timeout:
@@ -564,6 +953,7 @@ class HTTPBenchmarkEngine:
                 mtls_cert=self.mtls_cert,
                 mtls_key=self.mtls_key,
                 local_address=self.local_address,
+                enable_push_detection=self.enable_push_detection,
             )
         return self._transports[origin]
 
@@ -575,6 +965,9 @@ class HTTPBenchmarkEngine:
 
         if origin not in self._clients:
             transport = self._get_transport(url)
+            client_cookies: Union[Dict[str, str], httpx.Cookies] = self.cookies
+            if self.use_cookie_jar and not isinstance(client_cookies, httpx.Cookies):
+                client_cookies = httpx.Cookies()
             client_kwargs: Dict[str, Any] = dict(
                 transport=transport,
                 http2=self.http2,
@@ -582,7 +975,7 @@ class HTTPBenchmarkEngine:
                 follow_redirects=self.follow_redirects,
                 timeout=httpx.Timeout(self._timeout),
                 headers=self.extra_headers,
-                cookies=self.cookies or None,
+                cookies=client_cookies if client_cookies else None,
             )
             if self.auth:
                 client_kwargs["auth"] = self.auth
@@ -603,6 +996,22 @@ class HTTPBenchmarkEngine:
     def get_failed_targets(self) -> Dict[str, int]:
         return dict(self.failed_targets)
 
+    # Used by load_test.py for connection-reuse rate calculation
+    def get_connection_stats(
+        self, target: str, connection_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Pass connection_id (from HTTPResult.connection_id, requires
+        enable_connection_reuse=True) to safely inspect one specific
+        connection's metrics. Without it, "latest_metrics" is a best-effort
+        snapshot only reliable when no concurrent requests are in flight.
+        """
+        transport = self._get_transport(target)
+        return {
+            "connections_opened": transport.get_connections_opened(),
+            "latest_metrics": transport.get_connection_metrics(connection_id),
+        }
+
     def _run_assertions(self, response: httpx.Response, body: bytes) -> Dict[str, bool]:
         results: Dict[str, bool] = {}
         for name, config in self.assertions.items():
@@ -610,6 +1019,10 @@ class HTTPBenchmarkEngine:
                 results[name] = response.status_code == config
             elif name == "body_contains":
                 results[name] = config in body.decode("utf-8", errors="ignore")
+            elif name == "body_regex":
+                results[name] = bool(
+                    re.search(config, body.decode("utf-8", errors="ignore"))
+                )
             elif name == "header_exists":
                 results[name] = config in response.headers
             elif name == "header_value":
@@ -686,6 +1099,27 @@ class HTTPBenchmarkEngine:
             return HTTPProtocol.HTTP1, "http/1.1"
         return HTTPProtocol.UNKNOWN, None
 
+    @staticmethod
+    def _get_connection_metrics_for_response(
+        response: httpx.Response, transport: MetricsCapturingTransport
+    ) -> Dict[str, Any]:
+        """
+        Prefer the metrics dict belonging
+        to the exact connection this response came from — httpcore attaches
+        the AsyncNetworkStream it used as the "network_stream" extension, and
+        httpx forwards extensions through. Falls back to the transport-level
+        (possibly stale under concurrency) snapshot if the extension isn't
+        present, so this never raises and still works on older
+        httpx/httpcore that may not expose it.
+        """
+        try:
+            network_stream = response.extensions.get("network_stream")
+            if network_stream is not None and hasattr(network_stream, "get_metrics"):
+                return cast(Dict[str, Any], network_stream.get_metrics())
+        except Exception:
+            pass
+        return transport.get_connection_metrics()
+
     # ------------------------------------------------------------------
     # Single request
     # ------------------------------------------------------------------
@@ -694,6 +1128,7 @@ class HTTPBenchmarkEngine:
         self,
         target: str,
         iteration: int = 1,
+        multipart_file_size: int = 0,  # --- 0.5.1: item 12, upload throughput
     ) -> HTTPResult:
         """Execute a single HTTP request with retry logic."""
         await self._ensure_async_primitives()
@@ -701,6 +1136,7 @@ class HTTPBenchmarkEngine:
 
         start_time = time.time()
         client, transport = await self._get_client(target)
+        origin = self._origin(target)
 
         for attempt in range(self.max_retries + 1):
             try:
@@ -733,11 +1169,36 @@ class HTTPBenchmarkEngine:
                         request_id = uuid.uuid4().hex[:8]
                         req_headers["X-Request-ID"] = request_id
 
+                    content_to_send = self.body
+                    upload_start = None
+                    upload_time_ms: Optional[float] = None
+                    upload_size_bytes: Optional[int] = None
+
+                    # --- 0.5.1: item 12 — multipart upload throughput
+                    if multipart_file_size > 0:
+                        random_data = os.urandom(multipart_file_size)
+                        boundary = uuid.uuid4().hex
+                        multipart_body = (
+                            (
+                                f"--{boundary}\r\n"
+                                'Content-Disposition: form-data; name="file"; filename="random.bin"\r\n'
+                                "Content-Type: application/octet-stream\r\n\r\n"
+                            ).encode()
+                            + random_data
+                            + f"\r\n--{boundary}--\r\n".encode()
+                        )
+                        content_to_send = multipart_body
+                        upload_size_bytes = len(content_to_send)
+                        req_headers["Content-Type"] = (
+                            f"multipart/form-data; boundary={boundary}"
+                        )
+                        upload_start = time.perf_counter()
+
                     async with client.stream(
                         method=self.method,
                         url=target,
                         headers=req_headers,
-                        content=self.body,
+                        content=content_to_send,
                     ) as response:
                         headers_received = time.perf_counter()
                         ttfb_ms = (headers_received - start_time) * 1000
@@ -746,6 +1207,16 @@ class HTTPBenchmarkEngine:
 
                     end_time = time.perf_counter()
                     total_ms = (end_time - start_time) * 1000
+
+                    if upload_start is not None and upload_size_bytes is not None:
+                        upload_time_ms = (end_time - upload_start) * 1000
+                        upload_throughput_mbps = (
+                            (upload_size_bytes * 8) / (upload_time_ms * 1000)
+                            if upload_time_ms > 0
+                            else 0.0
+                        )
+                    else:
+                        upload_throughput_mbps = None
 
                     # Check max_latency assertion if defined
                     if "max_latency" in self.assertions:
@@ -843,10 +1314,17 @@ class HTTPBenchmarkEngine:
                         http2_expected=http2_expected,
                         http2_downgraded=http2_downgraded,
                         query_params=self.query_params,
+                        upload_size_bytes=upload_size_bytes,
+                        upload_time_ms=upload_time_ms,
+                        upload_throughput_mbps=upload_throughput_mbps,
                     )
 
-                    # Populate connection-level metrics from the timing backend
-                    metrics = transport.get_connection_metrics()
+                    # --- 0.5.1: fix #1 — read metrics for the exact
+                    # connection this response used, not the backend's
+                    # last-write snapshot.
+                    metrics = self._get_connection_metrics_for_response(
+                        response, transport
+                    )
                     result.tcp_connect_ms = metrics.get("tcp_connect_ms")
                     result.tls_handshake_ms = metrics.get("tls_handshake_ms")
                     result.ip_version = metrics.get("ip_version")
@@ -864,6 +1342,33 @@ class HTTPBenchmarkEngine:
                         result.cert_issuer_cn = issuer_cn
                         result.cert_sans = sans
                         result.cert_wildcard = wildcard
+
+                    # connection reuse detection
+                    if self.enable_connection_reuse:
+                        connection_id = metrics.get("connection_id")
+                        if connection_id:
+                            result.connection_id = connection_id
+                            seen = self._last_connection_id.setdefault(origin, set())
+                            result.connection_reused = connection_id in seen
+                            seen.add(connection_id)
+
+                    # TFO (always None, see HTTPResult.tcp_fast_open docstring)
+                    if self.enable_tfo_detection:
+                        result.tcp_fast_open = metrics.get("tcp_fast_open")
+
+                    # TLS resumption / session ticket
+                    if self.enable_tls_resumption:
+                        result.tls_resumed = metrics.get("tls_resumed", False)
+                    if self.enable_tls_resumption or self.enable_session_ticket:
+                        result.tls_session_id = metrics.get("tls_session_id")
+                    if self.enable_session_ticket:
+                        result.session_ticket = metrics.get("session_ticket", False)
+
+                    # HTTP/2 push detection
+                    if self.enable_push_detection and protocol == HTTPProtocol.HTTP2:
+                        push_promises = transport.get_recent_push_promises()
+                        result.http2_push_count = len(push_promises)
+                        result.http2_pushes = [p["url"] for p in push_promises]
 
                     await self._update_progress()
                     return result
@@ -973,6 +1478,57 @@ class HTTPBenchmarkEngine:
             dns_resolve_ms=dns_ms if dns_error is None else None,
             dns_resolver_ip=self.dns_resolver_ip,
         )
+
+    # ------------------------------------------------------------------
+    # WebSocket handshake timing
+    # ------------------------------------------------------------------
+
+    async def websocket_single(self, target: str, iteration: int = 1) -> HTTPResult:
+        """
+        Perform a WebSocket handshake and measure the time to establish.
+
+        Requires aiohttp to be installed (pip install net-benchmark[websocket]).
+        """
+        if not _AIOHTTP_AVAILABLE:
+            raise ImportError(
+                "aiohttp is required for WebSocket tests. Install with 'pip install net-benchmark[websocket]'"
+            )
+
+        await self._ensure_async_primitives()
+        assert self.semaphore is not None
+
+        start = time.perf_counter()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.ws_connect(target) as _:
+                    ws_handshake_done = time.perf_counter()
+                    handshake_ms = (ws_handshake_done - start) * 1000
+                    result = HTTPResult(
+                        target=target,
+                        method="GET",
+                        start_time=start,
+                        end_time=ws_handshake_done,
+                        total_ms=handshake_ms,
+                        status=QueryStatus.SUCCESS,
+                        iteration=iteration,
+                        websocket_handshake_ms=handshake_ms,
+                    )
+                    await self._update_progress()
+                    return result
+        except Exception as e:
+            end = time.perf_counter()
+            result = HTTPResult(
+                target=target,
+                method="GET",
+                start_time=start,
+                end_time=end,
+                total_ms=(end - start) * 1000,
+                status=QueryStatus.UNKNOWN_ERROR,
+                iteration=iteration,
+                error_message=str(e),
+            )
+            await self._update_progress()
+            return result
 
     # ------------------------------------------------------------------
     # Warmup

--- a/src/net_benchmark/http_bench/load_test.py
+++ b/src/net_benchmark/http_bench/load_test.py
@@ -1,0 +1,457 @@
+"""
+Load testing engine (0.5.1): throughput, sustained rate, ramp-up.
+Stats reuse HTTPAnalyzer/TargetStats from analysis.py — no separate
+percentile/latency implementation.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from net_benchmark.http_bench.analysis import HTTPAnalyzer, TargetStats
+from net_benchmark.http_bench.core import HTTPBenchmarkEngine, HTTPResult
+
+
+@dataclass
+class ConnectionReuseStats:
+    """Keep-alive / connection-reuse detection (roadmap item 4).
+
+    Kept separate from TargetStats.connection_reuse_rate (analysis.py) —
+    that field is a rate over *completed* requests, computed from the
+    connection_reused flag on each HTTPResult. This dataclass instead holds
+    the raw TCP-connection-open count from the transport layer
+    (HTTPBenchmarkEngine.get_connection_stats), which TargetStats has no
+    equivalent for.
+    """
+
+    total_requests: int
+    connections_opened: int
+
+    @property
+    def connections_reused(self) -> int:
+        return max(0, self.total_requests - self.connections_opened)
+
+    @property
+    def reuse_rate(self) -> float:
+        """0-1 fraction, unlike TargetStats.connection_reuse_rate which is
+        0-100 — kept as a fraction here since this predates and is
+        independent of the analysis.py field; exporters/CLI should be
+        explicit about which one they're reading."""
+        if self.total_requests == 0:
+            return 0.0
+        return self.connections_reused / self.total_requests
+
+
+class LoadTestMode(str, Enum):
+    THROUGHPUT = "throughput"  # item 1 — measure max achievable RPS
+    SUSTAINED = "sustained"  # item 2 — N requests over T seconds at fixed rate
+    RAMP_UP = "ramp_up"  # item 3 — gradually increasing concurrency
+
+
+@dataclass
+class IntervalStats:
+    """One time bucket (default 1s) of results, for time-series charts
+    (roadmap item 14). `stats` is a full TargetStats computed by running
+    HTTPAnalyzer over just this bucket's results — same percentile/latency
+    math as everywhere else, not a separate calculation.
+    """
+
+    window_index: int  # seconds since test start
+    stats: TargetStats
+    status_code_distribution: List[Dict[str, Any]]
+
+
+@dataclass
+class LoadTestSummary:
+    mode: LoadTestMode
+    target: str
+    duration_s: float
+    target_rps: Optional[float]
+    # Overall run stats — a TargetStats from analysis.py, same as what
+    # HTTPAnalyzer.get_target_statistics() would produce for a regular
+    # `http benchmark` run against this target. Note: TargetStats.success_rate
+    # and .connection_reuse_rate are 0-100 (percentages), not 0-1 fractions.
+    stats: TargetStats
+    status_code_distribution: List[Dict[str, Any]]
+    connection_reuse: ConnectionReuseStats
+    intervals: List[IntervalStats]
+    results: List[HTTPResult]
+
+    @property
+    def achieved_rps(self) -> float:
+        return (
+            (self.stats.total_requests / self.duration_s)
+            if self.duration_s > 0
+            else 0.0
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mode": self.mode.value,
+            "target": self.target,
+            "duration_s": self.duration_s,
+            "target_rps": self.target_rps,
+            "achieved_rps": self.achieved_rps,
+            "stats": vars(self.stats),
+            "status_code_distribution": self.status_code_distribution,
+            "connection_reuse": {
+                "total_requests": self.connection_reuse.total_requests,
+                "connections_opened": self.connection_reuse.connections_opened,
+                "connections_reused": self.connection_reuse.connections_reused,
+                "reuse_rate": self.connection_reuse.reuse_rate,
+            },
+            "intervals": [
+                {
+                    "window_index": iv.window_index,
+                    "stats": vars(iv.stats),
+                    "status_code_distribution": iv.status_code_distribution,
+                }
+                for iv in self.intervals
+            ],
+        }
+
+
+@dataclass
+class _TimedResult:
+    result: HTTPResult
+    completed_at_offset_s: float  # seconds since load test start
+
+
+def _empty_target_stats(target: str) -> TargetStats:
+    """Zeroed TargetStats for the (rare) case a run produced no results at
+    all — HTTPAnalyzer can't compute stats from an empty DataFrame, so this
+    is the explicit fallback rather than an IndexError on get_target_statistics()[0].
+    """
+    return TargetStats(
+        target=target,
+        method="",
+        total_requests=0,
+        successful_requests=0,
+        success_rate=0.0,
+        min_latency=0.0,
+        max_latency=0.0,
+        avg_latency=0.0,
+        median_latency=0.0,
+        std_latency=0.0,
+        p95_latency=0.0,
+        p99_latency=0.0,
+    )
+
+
+def _build_intervals(
+    timed_results: List[_TimedResult], bucket_s: float = 1.0
+) -> List[IntervalStats]:
+    """Buckets results into time windows and runs HTTPAnalyzer over each
+    bucket independently. Buckets with zero results are skipped rather than
+    synthesized as zeroed stats (HTTPAnalyzer has nothing to compute from an
+    empty result set) — this means a gap second just has no data point on
+    the timeline rather than a misleading zero-dip.
+    """
+    if not timed_results:
+        return []
+    max_offset = max(tr.completed_at_offset_s for tr in timed_results)
+    num_buckets = int(max_offset // bucket_s) + 1
+    buckets: List[List[HTTPResult]] = [[] for _ in range(num_buckets)]
+    for tr in timed_results:
+        idx = min(int(tr.completed_at_offset_s // bucket_s), num_buckets - 1)
+        buckets[idx].append(tr.result)
+
+    intervals: List[IntervalStats] = []
+    for idx, bucket in enumerate(buckets):
+        if not bucket:
+            continue
+        analyzer = HTTPAnalyzer(bucket)
+        target_stats_list = analyzer.get_target_statistics()
+        # Single target per LoadTestEngine instance, so exactly one group.
+        stats = (
+            target_stats_list[0]
+            if target_stats_list
+            else _empty_target_stats(bucket[0].target)
+        )
+        status_dist = analyzer.get_status_code_distribution()
+        intervals.append(
+            IntervalStats(
+                window_index=idx, stats=stats, status_code_distribution=status_dist
+            )
+        )
+    return intervals
+
+
+def _summarize(
+    mode: LoadTestMode,
+    target: str,
+    duration_s: float,
+    timed_results: List[_TimedResult],
+    target_rps: Optional[float],
+    connections_opened: int,
+) -> LoadTestSummary:
+    results = [tr.result for tr in timed_results]
+
+    if results:
+        analyzer = HTTPAnalyzer(results)
+        target_stats_list = analyzer.get_target_statistics()
+        stats = (
+            target_stats_list[0] if target_stats_list else _empty_target_stats(target)
+        )
+        status_dist = analyzer.get_status_code_distribution()
+    else:
+        stats = _empty_target_stats(target)
+        status_dist = []
+
+    return LoadTestSummary(
+        mode=mode,
+        target=target,
+        duration_s=duration_s,
+        target_rps=target_rps,
+        stats=stats,
+        status_code_distribution=status_dist,
+        connection_reuse=ConnectionReuseStats(
+            total_requests=len(results), connections_opened=connections_opened
+        ),
+        intervals=_build_intervals(timed_results),
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LoadTestEngine
+# ---------------------------------------------------------------------------
+
+
+class LoadTestEngine:
+    """Wraps a single-target HTTPBenchmarkEngine with load-shaping strategies.
+
+    One LoadTestEngine == one target. For multi-target load tests, construct
+    one instance per target (each gets its own pooled client/transport via
+    the underlying HTTPBenchmarkEngine, so origins never share connections).
+    """
+
+    def __init__(self, target: str, http_engine: Optional[HTTPBenchmarkEngine] = None):
+        self.target = target
+        # max_concurrent is set high by default here; individual run_* methods
+        # bound actual in-flight concurrency themselves via their own
+        # semaphores/pacing, so the engine-level cap just needs to not be the
+        # bottleneck.
+        self.engine = http_engine or HTTPBenchmarkEngine(max_concurrent=1000)
+        self._start_time: float = 0.0
+
+    def _offset(self) -> float:
+        return time.perf_counter() - self._start_time
+
+    async def _connections_opened(self) -> int:
+        stats = self.engine.get_connection_stats(self.target)
+        return int(stats["connections_opened"])
+
+    async def close(self) -> None:
+        await self.engine.close()
+
+    # ------------------------------------------------------------------
+    # Item 1 — RPS throughput measurement
+    # ------------------------------------------------------------------
+
+    async def run_throughput(
+        self,
+        duration_s: float = 10.0,
+        max_concurrency: int = 200,
+    ) -> LoadTestSummary:
+        """Saturate the target with up to `max_concurrency` concurrent
+        requests for `duration_s` and report the achieved RPS.
+        """
+        self._start_time = time.perf_counter()
+        semaphore = asyncio.Semaphore(max_concurrency)
+        timed_results: List[_TimedResult] = []
+        lock = asyncio.Lock()
+        stop_at = self._start_time + duration_s
+        in_flight: List[asyncio.Task[None]] = []
+
+        async def worker() -> None:
+            async with semaphore:
+                result = await self.engine.request_single(self.target)
+                async with lock:
+                    timed_results.append(_TimedResult(result, self._offset()))
+
+        while time.perf_counter() < stop_at:
+            in_flight = [t for t in in_flight if not t.done()]
+            if len(in_flight) < max_concurrency:
+                in_flight.append(asyncio.create_task(worker()))
+            else:
+                await asyncio.sleep(0)
+
+        if in_flight:
+            await asyncio.gather(*in_flight)
+
+        actual_duration = self._offset()
+        opened = await self._connections_opened()
+        return _summarize(
+            LoadTestMode.THROUGHPUT,
+            self.target,
+            actual_duration,
+            timed_results,
+            target_rps=None,
+            connections_opened=opened,
+        )
+
+    # ------------------------------------------------------------------
+    # Item 2 — Sustained load: N requests over T seconds, at a fixed rate
+    # ------------------------------------------------------------------
+
+    async def run_sustained(
+        self,
+        target_rps: float,
+        duration_s: float,
+        max_concurrency: Optional[int] = None,
+    ) -> LoadTestSummary:
+        """Fire requests at a fixed target_rps for duration_s using a simple
+        token-bucket pacer.
+        """
+        if target_rps <= 0:
+            raise ValueError("target_rps must be > 0")
+
+        cap = max_concurrency or max(int(target_rps * 2), 10)
+        semaphore = asyncio.Semaphore(cap)
+        timed_results: List[_TimedResult] = []
+        lock = asyncio.Lock()
+
+        self._start_time = time.perf_counter()
+        interval = 1.0 / target_rps
+        stop_at = self._start_time + duration_s
+        in_flight: List[asyncio.Task[None]] = []
+
+        async def worker() -> None:
+            async with semaphore:
+                result = await self.engine.request_single(self.target)
+                async with lock:
+                    timed_results.append(_TimedResult(result, self._offset()))
+
+        next_fire = self._start_time
+        while next_fire < stop_at:
+            now = time.perf_counter()
+            if now < next_fire:
+                await asyncio.sleep(next_fire - now)
+            in_flight.append(asyncio.create_task(worker()))
+            in_flight = [t for t in in_flight if not t.done()]
+            next_fire += interval
+
+        if in_flight:
+            await asyncio.gather(*in_flight)
+
+        actual_duration = self._offset()
+        opened = await self._connections_opened()
+        return _summarize(
+            LoadTestMode.SUSTAINED,
+            self.target,
+            actual_duration,
+            timed_results,
+            target_rps=target_rps,
+            connections_opened=opened,
+        )
+
+    # ------------------------------------------------------------------
+    # Item 3 — Ramp-up mode: gradually increase concurrency, then hold
+    # ------------------------------------------------------------------
+
+    async def run_ramp_up(
+        self,
+        start_concurrency: int,
+        max_concurrency: int,
+        ramp_duration_s: float,
+        hold_duration_s: float = 0.0,
+        step_interval_s: float = 1.0,
+        max_total_rps: Optional[float] = None,
+    ) -> LoadTestSummary:
+        """Step concurrency up linearly from start_concurrency to
+        max_concurrency over ramp_duration_s, then hold at max_concurrency
+        for hold_duration_s. Each concurrency "slot" keeps issuing
+        back-to-back requests for as long as it's alive, so RPS scales with
+        concurrency naturally rather than being separately paced.
+
+        max_total_rps is a safety ceiling, not a target rate (use
+        run_sustained for that). It exists because, unlike run_throughput
+        (bounded by its semaphore) and run_sustained (bounded by its pacer),
+        nothing here otherwise limits how fast slots fire against a very
+        fast target (e.g. localhost, a CDN edge, or a mocked client in
+        tests) — a single slot can spin as fast as the event loop allows.
+        Default ceiling is generous (concurrency * 50 rps) so it only
+        kicks in for genuinely pathological cases; pass None to disable.
+        """
+        if start_concurrency < 1:
+            raise ValueError("start_concurrency must be >= 1")
+        if max_concurrency < start_concurrency:
+            raise ValueError("max_concurrency must be >= start_concurrency")
+
+        self._start_time = time.perf_counter()
+        timed_results: List[_TimedResult] = []
+        lock = asyncio.Lock()
+        stop_event = asyncio.Event()
+
+        num_steps = max(1, int(ramp_duration_s // step_interval_s))
+        concurrency_delta = max_concurrency - start_concurrency
+
+        # Safety ceiling: a simple shared token bucket. Default scales with
+        # max_concurrency so normal (real-latency) runs never touch it —
+        # it's only a backstop against a runaway fast target.
+        effective_ceiling = (
+            max_total_rps if max_total_rps is not None else max_concurrency * 50
+        )
+        ceiling_interval = 1.0 / effective_ceiling if effective_ceiling > 0 else 0.0
+        _next_allowed_fire = time.perf_counter()
+        _ceiling_lock = asyncio.Lock()
+
+        async def _throttle() -> None:
+            """Blocks until the shared rate ceiling allows another request.
+            No-op (modulo the lock) once real request latency already keeps
+            the aggregate rate under the ceiling."""
+            nonlocal _next_allowed_fire
+            if ceiling_interval <= 0:
+                return
+            async with _ceiling_lock:
+                now = time.perf_counter()
+                wait = _next_allowed_fire - now
+                if wait > 0:
+                    await asyncio.sleep(wait)
+                    now = time.perf_counter()
+                _next_allowed_fire = max(now, _next_allowed_fire) + ceiling_interval
+
+        async def slot_worker() -> None:
+            while not stop_event.is_set():
+                await _throttle()
+                result = await self.engine.request_single(self.target)
+                async with lock:
+                    timed_results.append(_TimedResult(result, self._offset()))
+
+        active_slots: List[asyncio.Task[None]] = []
+
+        def target_concurrency_at_step(step: int) -> int:
+            if num_steps <= 1:
+                return max_concurrency
+            frac = step / (num_steps - 1)
+            return start_concurrency + int(round(concurrency_delta * frac))
+
+        for step in range(num_steps):
+            desired = target_concurrency_at_step(step)
+            while len(active_slots) < desired:
+                active_slots.append(asyncio.create_task(slot_worker()))
+            if step < num_steps - 1:
+                await asyncio.sleep(step_interval_s)
+
+        while len(active_slots) < max_concurrency:
+            active_slots.append(asyncio.create_task(slot_worker()))
+
+        if hold_duration_s > 0:
+            await asyncio.sleep(hold_duration_s)
+
+        stop_event.set()
+        await asyncio.gather(*active_slots, return_exceptions=True)
+
+        actual_duration = self._offset()
+        opened = await self._connections_opened()
+        return _summarize(
+            LoadTestMode.RAMP_UP,
+            self.target,
+            actual_duration,
+            timed_results,
+            target_rps=None,
+            connections_opened=opened,
+        )

--- a/src/net_benchmark/http_bench/load_test_exporters.py
+++ b/src/net_benchmark/http_bench/load_test_exporters.py
@@ -1,0 +1,600 @@
+"""
+CSV/Excel/PDF/JSON export for load test results. Takes
+List[LoadTestSummary] (one per target) so Excel gets a per-URL sheet.
+Reuses base.py's table/chart helpers; adds a local line-chart helper
+for time-series (base.py's generate_bar_chart is bar-only).
+"""
+
+import base64
+import os
+import re
+import tempfile
+from collections import Counter
+from datetime import datetime
+from typing import Dict, List, Optional, Set
+
+import matplotlib
+import matplotlib.pyplot as plt
+import pandas as pd
+from openpyxl import Workbook
+
+from net_benchmark.dns_benchmark.core import QueryStatus
+from net_benchmark.exporters.base import (
+    add_simple_table_sheet,
+    embed_charts_sheet,
+    generate_bar_chart,
+    html_page,
+)
+from net_benchmark.http_bench.load_test import LoadTestSummary
+
+try:
+    from weasyprint import HTML
+except ImportError:
+    HTML = None
+
+
+matplotlib.use("Agg")
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_EXCEL_INVALID_CHARS = re.compile(r"[:\\/?*\[\]]")
+
+
+def _sheet_name(target: str, suffix: str = "", used: Optional[Set[str]] = None) -> str:
+    """Excel sheet names: max 31 chars, no : \\ / ? * [ ]. Truncates and
+    de-dupes against `used` (mutated in place) so multiple targets that
+    truncate to the same prefix don't collide.
+    """
+    stripped = target.replace("https://", "").replace("http://", "")
+    clean = _EXCEL_INVALID_CHARS.sub("_", stripped)
+    max_len = 31 - len(suffix)
+    name = (clean[:max_len] + suffix) if max_len > 0 else clean[:31]
+    if used is None:
+        return name
+    base_name = name
+    i = 2
+    while name in used:
+        candidate_suffix = f"~{i}"
+        name = base_name[: 31 - len(candidate_suffix)] + candidate_suffix
+        i += 1
+    used.add(name)
+    return name
+
+
+def error_breakdown(summary: LoadTestSummary) -> Dict[str, int]:
+    """Error message counts for a single target's load test — mirrors
+    HTTPAnalyzer.get_error_statistics() but works directly off
+    LoadTestSummary.results since load tests don't go through HTTPAnalyzer
+    for the raw-result path (only for the aggregate stats).
+    """
+    counts = Counter(
+        r.error_message or f"HTTP {r.http_status_code}"
+        for r in summary.results
+        if r.status != QueryStatus.SUCCESS
+    )
+    return dict(counts)
+
+
+def combined_error_breakdown(summaries: List[LoadTestSummary]) -> Dict[str, int]:
+    total: Counter[str] = Counter()
+    for s in summaries:
+        total.update(error_breakdown(s))
+    return dict(total)
+
+
+def _generate_line_chart(
+    x_values: List[float],
+    series: Dict[str, List[float]],
+    xlabel: str,
+    ylabel: str,
+    title: str,
+    output_path: str,
+) -> str:
+    """Local line-chart helper (see module docstring for why this isn't in
+    base.py). Same contract as generate_bar_chart: saves a PNG, returns the
+    path. Multiple named series are overlaid on one axis.
+    """
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    for label, y_values in series.items():
+        ax.plot(x_values, y_values, label=label, linewidth=1.6)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    if len(series) > 1:
+        ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return output_path
+
+
+def _latency_timeline_chart(summary: LoadTestSummary, output_path: str) -> str:
+    x = [float(iv.window_index) for iv in summary.intervals]
+    series = {
+        "avg (ms)": [iv.stats.avg_latency for iv in summary.intervals],
+        "p95 (ms)": [iv.stats.p95_latency for iv in summary.intervals],
+        "p99 (ms)": [iv.stats.p99_latency for iv in summary.intervals],
+    }
+    return _generate_line_chart(
+        x,
+        series,
+        "Elapsed (s)",
+        "Latency (ms)",
+        f"Latency over time — {summary.target}",
+        output_path,
+    )
+
+
+def _throughput_timeline_chart(summary: LoadTestSummary, output_path: str) -> str:
+    x = [float(iv.window_index) for iv in summary.intervals]
+    # Each interval bucket is ~1s, so request count in that bucket ≈ RPS for
+    # that second.
+    series = {
+        "Achieved RPS": [float(iv.stats.total_requests) for iv in summary.intervals]
+    }
+    if summary.target_rps:
+        series["Target RPS"] = [summary.target_rps for _ in summary.intervals]
+    return _generate_line_chart(
+        x,
+        series,
+        "Elapsed (s)",
+        "Requests/sec",
+        f"Throughput over time — {summary.target}",
+        output_path,
+    )
+
+
+def _status_code_chart(summary: LoadTestSummary, output_path: str) -> str:
+    # status_code_distribution is a List[Dict] from
+    # HTTPAnalyzer.get_status_code_distribution(): [{"status_code": 200, "count": N, "pct": ...}, ...]
+    dist = sorted(summary.status_code_distribution, key=lambda row: row["status_code"])
+    names = [str(row["status_code"]) for row in dist]
+    values = [row["count"] for row in dist]
+    return generate_bar_chart(
+        names=names,
+        values=values,
+        ylabel="Request count",
+        title=f"Status code distribution — {summary.target}",
+        output_path=output_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON bundle
+# ---------------------------------------------------------------------------
+
+
+class LoadTestExportBundle:
+    @staticmethod
+    def export_json(summaries: List[LoadTestSummary], output_path: str) -> None:
+        import json
+
+        payload = {
+            "targets": [s.to_dict() for s in summaries],
+            "combined_error_breakdown": combined_error_breakdown(summaries),
+            "generated_at": datetime.now().isoformat(),
+        }
+        with open(output_path, "w") as f:
+            json.dump(payload, f, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class LoadTestCSVExporter:
+    """One static method per export type, mirroring HTTPCSVExporter."""
+
+    @staticmethod
+    def export_raw_results(summaries: List[LoadTestSummary], output_path: str) -> None:
+        rows = []
+        for s in summaries:
+            for r in s.results:
+                row = r.to_dict()
+                row["load_test_mode"] = s.mode.value
+                row["load_test_target_rps"] = s.target_rps
+                rows.append(row)
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_summary(summaries: List[LoadTestSummary], output_path: str) -> None:
+        rows = []
+        for s in summaries:
+            rows.append(
+                {
+                    "target": s.target,
+                    "mode": s.mode.value,
+                    "duration_s": round(s.duration_s, 2),
+                    "total_requests": s.stats.total_requests,
+                    "successful_requests": s.stats.successful_requests,
+                    "success_rate_pct": round(s.stats.success_rate, 2),
+                    "achieved_rps": round(s.achieved_rps, 2),
+                    "target_rps": s.target_rps,
+                    "min_latency_ms": round(s.stats.min_latency, 2),
+                    "avg_latency_ms": round(s.stats.avg_latency, 2),
+                    "median_latency_ms": round(s.stats.median_latency, 2),
+                    "p95_latency_ms": round(s.stats.p95_latency, 2),
+                    "p99_latency_ms": round(s.stats.p99_latency, 2),
+                    "max_latency_ms": round(s.stats.max_latency, 2),
+                    "jitter_ms": round(s.stats.jitter, 2),
+                    "connections_opened": s.connection_reuse.connections_opened,
+                    "connections_reused": s.connection_reuse.connections_reused,
+                    "reuse_rate_pct": round(s.connection_reuse.reuse_rate * 100, 2),
+                    # From analysis.py's TargetStats — computed from the
+                    # per-request connection_reused/tls_resumed flags,
+                    # distinct from connection_reuse (raw TCP-connect counts)
+                    "connection_reuse_rate_pct": round(
+                        s.stats.connection_reuse_rate, 2
+                    ),
+                    "tls_resumption_rate_pct": round(s.stats.tls_resumption_rate, 2),
+                    "http2_push_total": s.stats.http2_push_total,
+                }
+            )
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_intervals(summaries: List[LoadTestSummary], output_path: str) -> None:
+        rows = []
+        for s in summaries:
+            for iv in s.intervals:
+                rows.append(
+                    {
+                        "target": s.target,
+                        "window_index": iv.window_index,
+                        "request_count": iv.stats.total_requests,
+                        "success_count": iv.stats.successful_requests,
+                        "error_count": iv.stats.total_requests
+                        - iv.stats.successful_requests,
+                        "avg_latency_ms": round(iv.stats.avg_latency, 2),
+                        "p95_latency_ms": round(iv.stats.p95_latency, 2),
+                        "p99_latency_ms": round(iv.stats.p99_latency, 2),
+                    }
+                )
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+
+    @staticmethod
+    def export_error_breakdown(
+        summaries: List[LoadTestSummary], output_path: str
+    ) -> None:
+        rows = []
+        for s in summaries:
+            for message, count in error_breakdown(s).items():
+                rows.append(
+                    {"target": s.target, "error_message": message, "count": count}
+                )
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+
+
+# ---------------------------------------------------------------------------
+# Excel — one raw-requests sheet per target ("per-URL Excel sheet", item 15)
+# ---------------------------------------------------------------------------
+
+
+class LoadTestExcelExporter:
+    @staticmethod
+    def export_results(
+        summaries: List[LoadTestSummary],
+        output_path: str,
+        include_charts: bool = True,
+    ) -> None:
+        wb = Workbook()
+        wb.remove(wb.active)
+
+        temp_dir = None
+        chart_paths: List[str] = []
+
+        try:
+            LoadTestExcelExporter._add_comparison_sheet(wb, summaries)
+
+            used_names: Set[str] = set()
+            for s in summaries:
+                LoadTestExcelExporter._add_target_raw_sheet(wb, s, used_names)
+                LoadTestExcelExporter._add_target_timeline_sheet(wb, s, used_names)
+
+            error_dist = combined_error_breakdown(summaries)
+            if error_dist:
+                add_simple_table_sheet(
+                    wb,
+                    "Errors",
+                    pd.DataFrame(
+                        [{"error": k, "count": v} for k, v in error_dist.items()]
+                    ),
+                )
+
+            if include_charts:
+                temp_dir = tempfile.mkdtemp()
+                chart_paths = LoadTestExcelExporter._add_charts_sheet(
+                    wb, summaries, temp_dir
+                )
+
+            wb.save(output_path)
+        finally:
+            for p in chart_paths:
+                try:
+                    if os.path.exists(p):
+                        os.remove(p)
+                except OSError:
+                    pass
+            if temp_dir and os.path.exists(temp_dir):
+                try:
+                    os.rmdir(temp_dir)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _add_comparison_sheet(wb: Workbook, summaries: List[LoadTestSummary]) -> None:
+        rows = []
+        for s in summaries:
+            rows.append(
+                {
+                    "Target": s.target,
+                    "Mode": s.mode.value,
+                    "Duration (s)": round(s.duration_s, 2),
+                    "Total Requests": s.stats.total_requests,
+                    "Success Rate (%)": round(s.stats.success_rate, 2),
+                    "Achieved RPS": round(s.achieved_rps, 2),
+                    "Target RPS": s.target_rps if s.target_rps else "",
+                    "Avg (ms)": round(s.stats.avg_latency, 2),
+                    "P95 (ms)": round(s.stats.p95_latency, 2),
+                    "P99 (ms)": round(s.stats.p99_latency, 2),
+                    "Connections Opened": s.connection_reuse.connections_opened,
+                    "Reuse Rate (%)": round(s.connection_reuse.reuse_rate * 100, 2),
+                    "TLS Resumption Rate (%)": round(s.stats.tls_resumption_rate, 2),
+                }
+            )
+        add_simple_table_sheet(wb, "Summary", pd.DataFrame(rows))
+
+    @staticmethod
+    def _add_target_raw_sheet(
+        wb: Workbook, summary: LoadTestSummary, used_names: Set[str]
+    ) -> None:
+        data = []
+        for r in summary.results:
+            data.append(
+                {
+                    "Status": r.status.value,
+                    "HTTP Code": r.http_status_code or "",
+                    "Total (ms)": round(r.total_ms, 2),
+                    "TTFB (ms)": round(r.ttfb_ms, 2) if r.ttfb_ms else "",
+                    "Connection Reused": r.connection_reused,
+                    "Connection ID": r.connection_id or "",
+                    "TLS Resumed": r.tls_resumed,
+                    "Protocol": r.protocol.value,
+                    "Error": r.error_message or "",
+                }
+            )
+        name = _sheet_name(summary.target, suffix=" Raw", used=used_names)
+        add_simple_table_sheet(wb, name, pd.DataFrame(data))
+
+    @staticmethod
+    def _add_target_timeline_sheet(
+        wb: Workbook, summary: LoadTestSummary, used_names: Set[str]
+    ) -> None:
+        data = []
+        for iv in summary.intervals:
+            data.append(
+                {
+                    "Second": iv.window_index,
+                    "Requests": iv.stats.total_requests,
+                    "Success": iv.stats.successful_requests,
+                    "Errors": iv.stats.total_requests - iv.stats.successful_requests,
+                    "Avg (ms)": round(iv.stats.avg_latency, 2),
+                    "P95 (ms)": round(iv.stats.p95_latency, 2),
+                    "P99 (ms)": round(iv.stats.p99_latency, 2),
+                }
+            )
+        name = _sheet_name(summary.target, suffix=" Timeline", used=used_names)
+        add_simple_table_sheet(wb, name, pd.DataFrame(data))
+
+    @staticmethod
+    def _add_charts_sheet(
+        wb: Workbook, summaries: List[LoadTestSummary], temp_dir: str
+    ) -> List[str]:
+        chart_paths: List[str] = []
+        entries: List[str] = []
+
+        for i, s in enumerate(summaries):
+            safe_name = re.sub(r"[^a-zA-Z0-9]", "_", s.target)[:40]
+            if s.intervals:
+                lat_path = _latency_timeline_chart(
+                    s, os.path.join(temp_dir, f"latency_{i}_{safe_name}.png")
+                )
+                thr_path = _throughput_timeline_chart(
+                    s, os.path.join(temp_dir, f"throughput_{i}_{safe_name}.png")
+                )
+                chart_paths.extend([lat_path, thr_path])
+                entries.append(lat_path)
+                entries.append(thr_path)
+            if s.status_code_distribution:
+                status_path = _status_code_chart(
+                    s, os.path.join(temp_dir, f"status_{i}_{safe_name}.png")
+                )
+                chart_paths.append(status_path)
+                entries.append(status_path)
+
+        # embed_charts_sheet's loop unpacks (heading_cell, anchor_cell, path)
+        # — first cell gets bold formatting, second is where the image is
+        # anchored, 20 rows apart, matching the spacing HTTPExcelExporter
+        # uses ("A3","A4"), ("A23","A24"), etc.
+        anchored = []
+        row = 3
+        for path in entries:
+            anchored.append((f"A{row}", f"A{row + 1}", path))
+            row += 20
+
+        if anchored:
+            embed_charts_sheet(wb, "Charts", anchored, "Load Test Charts")
+
+        return chart_paths
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+class LoadTestPDFExporter:
+    @staticmethod
+    def export_results(
+        summaries: List[LoadTestSummary],
+        output_path: str,
+        include_charts: bool = True,
+    ) -> None:
+        if HTML is None:
+            raise RuntimeError(
+                "PDF export requires 'weasyprint'. "
+                "Install with: pip install net-benchmark[pdf]"
+            )
+
+        charts_dir = tempfile.mkdtemp()
+        chart_paths: List[str] = []
+
+        try:
+            chart_b64_by_target: Dict[str, Dict[str, str]] = {}
+
+            if include_charts:
+                for i, s in enumerate(summaries):
+                    safe_name = re.sub(r"[^a-zA-Z0-9]", "_", s.target)[:40]
+                    target_charts: Dict[str, str] = {}
+
+                    if s.intervals:
+                        lat_path = _latency_timeline_chart(
+                            s, os.path.join(charts_dir, f"latency_{i}_{safe_name}.png")
+                        )
+                        thr_path = _throughput_timeline_chart(
+                            s,
+                            os.path.join(charts_dir, f"throughput_{i}_{safe_name}.png"),
+                        )
+                        chart_paths.extend([lat_path, thr_path])
+                        with open(lat_path, "rb") as f:
+                            target_charts["latency"] = base64.b64encode(
+                                f.read()
+                            ).decode()
+                        with open(thr_path, "rb") as f:
+                            target_charts["throughput"] = base64.b64encode(
+                                f.read()
+                            ).decode()
+
+                    if s.status_code_distribution:
+                        status_path = _status_code_chart(
+                            s, os.path.join(charts_dir, f"status_{i}_{safe_name}.png")
+                        )
+                        chart_paths.append(status_path)
+                        with open(status_path, "rb") as f:
+                            target_charts["status"] = base64.b64encode(
+                                f.read()
+                            ).decode()
+
+                    chart_b64_by_target[s.target] = target_charts
+
+            html_content = LoadTestPDFExporter._generate_html(
+                summaries, chart_b64_by_target
+            )
+            HTML(string=html_content).write_pdf(output_path)
+
+        finally:
+            for p in chart_paths:
+                try:
+                    if os.path.exists(p):
+                        os.remove(p)
+                except OSError:
+                    pass
+            try:
+                os.rmdir(charts_dir)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _generate_html(
+        summaries: List[LoadTestSummary],
+        chart_b64_by_target: Dict[str, Dict[str, str]],
+    ) -> str:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        errors = combined_error_breakdown(summaries)
+
+        summary_rows = "".join(
+            f"<tr><td>{s.target}</td><td>{s.mode.value}</td>"
+            f"<td>{s.stats.total_requests}</td><td>{s.stats.success_rate:.1f}%</td>"
+            f"<td>{s.achieved_rps:.1f}</td>"
+            f"<td>{s.target_rps if s.target_rps else 'N/A'}</td>"
+            f"<td>{s.stats.avg_latency:.1f}</td><td>{s.stats.p95_latency:.1f}</td>"
+            f"<td>{s.stats.p99_latency:.1f}</td>"
+            f"<td>{s.connection_reuse.reuse_rate * 100:.1f}%</td></tr>"
+            for s in summaries
+        )
+
+        error_rows = (
+            "".join(
+                f"<tr><td>{message}</td><td>{count}</td></tr>"
+                for message, count in sorted(errors.items(), key=lambda kv: -kv[1])
+            )
+            or "<tr><td colspan='2'>No errors recorded</td></tr>"
+        )
+
+        chart_sections = ""
+        for s in summaries:
+            charts = chart_b64_by_target.get(s.target, {})
+            if not charts:
+                continue
+            chart_sections += f"<div class='section'><h2>Charts — {s.target}</h2>"
+            if "latency" in charts:
+                chart_sections += (
+                    f"<div class='chart'><img src='data:image/png;base64,"
+                    f"{charts['latency']}' alt='Latency over time'></div>"
+                )
+            if "throughput" in charts:
+                chart_sections += (
+                    f"<div class='chart'><img src='data:image/png;base64,"
+                    f"{charts['throughput']}' alt='Throughput over time'></div>"
+                )
+            if "status" in charts:
+                chart_sections += (
+                    f"<div class='chart'><img src='data:image/png;base64,"
+                    f"{charts['status']}' alt='Status code distribution'></div>"
+                )
+            chart_sections += "</div>"
+
+        total_requests = sum(s.stats.total_requests for s in summaries)
+        total_errors = sum(
+            s.stats.total_requests - s.stats.successful_requests for s in summaries
+        )
+
+        body = f"""
+        <div class="header">
+        <h1>Load Test Report</h1>
+        <p>Generated: {now}</p>
+        </div>
+
+        <div class="section">
+        <h2>Executive Summary</h2>
+        <p><strong>Targets tested:</strong> {len(summaries)}</p>
+        <p><strong>Total requests:</strong> {total_requests}</p>
+        <p><strong>Total errors:</strong> {total_errors}</p>
+        </div>
+
+        <div class="section">
+        <h2>Target Comparison</h2>
+        <table>
+        <tr><th>Target</th><th>Mode</th><th>Requests</th><th>Success</th>
+        <th>Achieved RPS</th><th>Target RPS</th><th>Avg (ms)</th>
+        <th>P95 (ms)</th><th>P99 (ms)</th><th>Reuse Rate</th></tr>
+            {summary_rows}
+        </table>
+        </div>
+
+        {chart_sections}
+
+        <div class="section">
+        <h2>Error Breakdown</h2>
+        <table>
+            <tr><th>Error</th><th>Count</th></tr>
+            {error_rows}
+        </table>
+        </div>
+        """
+        return html_page("Load Test Report", body)

--- a/src/net_benchmark/http_bench/tests/test_cli.py
+++ b/src/net_benchmark/http_bench/tests/test_cli.py
@@ -1,13 +1,24 @@
 """CLI integration tests for http benchmark commands."""
 
 import os
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from click.testing import CliRunner
 
+from net_benchmark.http_bench.analysis import TargetStats
 from net_benchmark.http_bench.cli import http
-from net_benchmark.http_bench.core import HTTPProtocol, HTTPResult, QueryStatus
+from net_benchmark.http_bench.core import (
+    HTTPProtocol,
+    HTTPResult,
+    QueryStatus,
+    TargetManager,
+)
+from net_benchmark.http_bench.load_test import (
+    ConnectionReuseStats,
+    LoadTestMode,
+    LoadTestSummary,
+)
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -76,6 +87,133 @@ def mock_run_benchmark(monkeypatch):
     monkeypatch.setattr(
         "net_benchmark.http_bench.cli.HTTPBenchmarkEngine.close",
         AsyncMock(),
+    )
+
+
+# Inside mock_load_test_components fixture
+@pytest.fixture
+def mock_load_test_components(monkeypatch):
+    # Patch engine classes in cli
+    monkeypatch.setattr("net_benchmark.http_bench.cli.HTTPBenchmarkEngine", MagicMock())
+    mock_engine_cls = MagicMock()
+    monkeypatch.setattr("net_benchmark.http_bench.cli.LoadTestEngine", mock_engine_cls)
+
+    # Patch exporter references directly in the cli module (where they are used)
+    monkeypatch.setattr("net_benchmark.http_bench.cli.LoadTestCSVExporter", MagicMock())
+    monkeypatch.setattr(
+        "net_benchmark.http_bench.cli.LoadTestExcelExporter", MagicMock()
+    )
+    monkeypatch.setattr("net_benchmark.http_bench.cli.LoadTestPDFExporter", MagicMock())
+    monkeypatch.setattr(
+        "net_benchmark.http_bench.cli.LoadTestExportBundle", MagicMock()
+    )
+
+    # Configure mock engine
+    def _engine_factory(target, http_engine=None):
+        engine = MagicMock()
+        engine.run_throughput = AsyncMock()
+        engine.run_sustained = AsyncMock()
+        engine.run_ramp_up = AsyncMock()
+        engine.close = AsyncMock()
+        engine.run_throughput.return_value = make_summary(target=target)
+        engine.run_sustained.return_value = make_summary(
+            target=target, mode=LoadTestMode.SUSTAINED, target_rps=100.0
+        )
+        engine.run_ramp_up.return_value = make_summary(
+            target=target, mode=LoadTestMode.RAMP_UP
+        )
+        return engine
+
+    mock_engine_cls.side_effect = _engine_factory
+    return mock_engine_cls
+
+
+# ---------------------------------------------------------------------------
+# Helpers for load test tests
+# ---------------------------------------------------------------------------
+
+
+def make_summary(
+    target="https://example.com",
+    mode=LoadTestMode.THROUGHPUT,
+    total_requests=100,
+    success_count=95,
+    achieved_rps=50.0,
+    target_rps=None,
+    connections_opened=3,
+) -> LoadTestSummary:
+    """Construct a minimal LoadTestSummary that matches the real engine output."""
+    stats = TargetStats(
+        target=target,
+        method="GET",
+        total_requests=total_requests,
+        successful_requests=success_count,
+        success_rate=(success_count / total_requests * 100) if total_requests else 0.0,
+        min_latency=5.0,
+        max_latency=200.0,
+        avg_latency=20.0,
+        median_latency=15.0,
+        std_latency=5.0,
+        p95_latency=100.0,
+        p99_latency=180.0,
+        jitter=2.0,
+        consistency_score=95.0,
+        avg_ttfb_ms=10.0,
+        p95_ttfb_ms=50.0,
+        http2_rate=80.0,
+        redirect_rate=10.0,
+        avg_response_size_bytes=2048.0,
+        avg_dns_ms=3.0,
+        avg_tcp_ms=5.0,
+        avg_tls_ms=12.0,
+        avg_compressed_size_bytes=1500.0,
+        avg_redirect_time_ms=0.0,
+        http2_downgrade_rate=0.0,
+        cache_control_present=50,
+        etag_present=40,
+        last_modified_present=30,
+        age_present=10,
+        hsts_present=80,
+        csp_present=60,
+        cdn_fingerprint="Cloudflare",
+        server_header="nginx",
+        cert_expiry_days_min=365,
+        alt_svc='h3=":443"',
+        ip_version="IPv4",
+        connection_reuse_rate=25.0,
+        tls_resumption_rate=40.0,
+        http2_push_total=0,
+        avg_upload_throughput_mbps=0.0,
+    )
+
+    reuse = ConnectionReuseStats(
+        total_requests=total_requests,
+        connections_opened=connections_opened,
+    )
+
+    status_dist = [
+        {
+            "status_code": 200,
+            "count": success_count,
+            "pct": round(success_count / total_requests * 100, 2),
+        },
+        {
+            "status_code": 500,
+            "count": total_requests - success_count,
+            "pct": round((total_requests - success_count) / total_requests * 100, 2),
+        },
+    ]
+
+    return LoadTestSummary(
+        mode=mode,
+        target=target,
+        duration_s=2.0,
+        target_rps=target_rps,
+        stats=stats,
+        status_code_distribution=status_dist,
+        connection_reuse=reuse,
+        intervals=[],
+        results=[],
     )
 
 
@@ -908,3 +1046,224 @@ class TestCompare:
         result = runner.invoke(http, ["compare", "a.com", "b.com", "--iterations", "1"])
         assert result.exit_code == 1
         assert "Error during comparison: test error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Load test command tests (0.5.1)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTest:
+    def test_missing_targets(self, runner):
+        result = runner.invoke(http, ["load-test"])
+        assert result.exit_code == 0
+        assert "Provide --targets or use --use-defaults" in result.output
+
+    def test_invalid_format(self, runner):
+        result = runner.invoke(
+            http, ["load-test", "--use-defaults", "--formats", "xml"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid format 'xml'" in result.output
+
+    def test_file_not_found(self, runner):
+        result = runner.invoke(http, ["load-test", "--targets", "nonexistent.txt"])
+        assert result.exit_code == 0
+        assert "Target file not found" in result.output
+
+    def test_sustained_missing_rps(self, runner):
+        result = runner.invoke(
+            http,
+            [
+                "load-test",
+                "--use-defaults",
+                "--mode",
+                "sustained",
+                "--duration",
+                "5",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "--mode sustained requires --rps" in result.output
+
+    def test_throughput_mode_exports(self, runner, mock_load_test_components):
+        result = runner.invoke(
+            http,
+            [
+                "load-test",
+                "--targets",
+                "https://example.com",
+                "--mode",
+                "throughput",
+                "--duration",
+                "2",
+                "--formats",
+                "csv,excel,json",
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Import the mocked exporters from cli
+        from net_benchmark.http_bench.cli import (
+            LoadTestCSVExporter,
+            LoadTestExcelExporter,
+            LoadTestExportBundle,
+            LoadTestPDFExporter,
+        )
+
+        LoadTestCSVExporter.export_raw_results.assert_called_once()
+        LoadTestCSVExporter.export_summary.assert_called_once()
+        LoadTestCSVExporter.export_intervals.assert_called_once()
+        LoadTestCSVExporter.export_error_breakdown.assert_called_once()
+        LoadTestExcelExporter.export_results.assert_called_once()
+        LoadTestExportBundle.export_json.assert_called_once()
+        LoadTestPDFExporter.export_results.assert_not_called()
+
+    def test_sustained_mode_summary_output(self, runner, mock_load_test_components):
+        result = runner.invoke(
+            http,
+            [
+                "load-test",
+                "--targets",
+                "https://example.com",
+                "--mode",
+                "sustained",
+                "--rps",
+                "100",
+                "--duration",
+                "2",
+                "--enable-connection-reuse",
+                "--formats",
+                "csv",
+            ],
+        )
+        assert result.exit_code == 0
+        output = result.output
+        assert "Mode:             sustained" in output
+        assert "Target RPS:       100.0" in output
+        assert "Achieved RPS:" in output
+        assert "Connections open:" in output
+        assert "Reuse rate:" in output
+        assert "TLS resumption:" not in output
+
+    def test_ramp_up_mode_config_output(self, runner, mock_load_test_components):
+        result = runner.invoke(
+            http,
+            [
+                "load-test",
+                "--targets",
+                "https://example.com",
+                "--mode",
+                "ramp-up",
+                "--start-concurrency",
+                "5",
+                "--ramp-concurrency",
+                "50",
+                "--ramp-duration",
+                "10",
+                "--hold-duration",
+                "5",
+                "--formats",
+                "csv",
+            ],
+        )
+        assert result.exit_code == 0
+        output = result.output
+        assert "Concurrency:  5 -> 50" in output
+        assert "Ramp:         10.0s, hold 5.0s" in output
+
+    def test_feature_flags_config_message(self, runner, mock_load_test_components):
+        result = runner.invoke(
+            http,
+            [
+                "load-test",
+                "--use-defaults",
+                "--mode",
+                "throughput",
+                "--enable-connection-reuse",
+                "--enable-tls-resumption",
+                "--enable-push-detection",
+                "--formats",
+                "csv",
+            ],
+        )
+        assert result.exit_code == 0
+        output = result.output
+        assert "Connection reuse tracking: on" in output
+        assert "TLS resumption detection:  on" in output
+        assert "HTTP/2 push detection:     on" in output
+
+    def test_multiple_targets_create_separate_engines(
+        self, runner, mock_load_test_components
+    ):
+        mock_cls = mock_load_test_components
+        mock_cls.reset_mock()
+
+        runner.invoke(
+            http,
+            [
+                "load-test",
+                "--targets",
+                "https://a.com,https://b.com",
+                "--mode",
+                "throughput",
+                "--duration",
+                "2",
+                "--formats",
+                "csv",
+                "--quiet",
+            ],
+        )
+        assert mock_cls.call_count == 2
+        calls = [c.args[0] for c in mock_cls.call_args_list]
+        assert "https://a.com" in calls
+        assert "https://b.com" in calls
+
+    def test_use_defaults_targets(self, runner, mock_load_test_components):
+        mock_cls = mock_load_test_components
+        mock_cls.reset_mock()
+
+        runner.invoke(
+            http,
+            [
+                "load-test",
+                "--use-defaults",
+                "--mode",
+                "throughput",
+                "--duration",
+                "2",
+                "--formats",
+                "csv",
+                "--quiet",
+            ],
+        )
+        expected = TargetManager.get_default_targets()
+        assert mock_cls.call_count == len(expected)
+        seen = [c.args[0] for c in mock_cls.call_args_list]
+        for t in expected:
+            assert t in seen
+
+    def test_output_directory_creation(
+        self, runner, mock_load_test_components, tmp_path
+    ):
+        out = tmp_path / "results"
+        runner.invoke(
+            http,
+            [
+                "load-test",
+                "--targets",
+                "https://example.com",
+                "--output",
+                str(out),
+                "--formats",
+                "csv",
+                "--quiet",
+            ],
+        )
+        assert out.exists()
+        # Since exporters are mocked, no real files are written.
+        # Verify that the exporter methods were called instead.
+        from net_benchmark.http_bench.cli import LoadTestCSVExporter
+
+        LoadTestCSVExporter.export_raw_results.assert_called_once()

--- a/src/net_benchmark/http_bench/tests/test_core.py
+++ b/src/net_benchmark/http_bench/tests/test_core.py
@@ -1,14 +1,18 @@
 import ssl
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from httpcore import AsyncConnectionPool
 from httpcore._backends.base import (
     AsyncNetworkStream,
 )
 
 from net_benchmark.http_bench.core import (
+    _AIOHTTP_AVAILABLE,
+    _H2_AVAILABLE,
     HTTPBenchmarkEngine,
+    HTTPDigestAuth,
     HTTPResult,
     MetricsCapturingTransport,
     QueryStatus,
@@ -17,6 +21,14 @@ from net_benchmark.http_bench.core import (
     TimingNetworkStream,
     _parse_cert_der,
 )
+
+if _H2_AVAILABLE:
+    import h2.events
+
+    from net_benchmark.http_bench.core import (
+        PushDetectingPool,
+        PushTrackingH2Connection,
+    )
 
 
 class TestTargetManager:
@@ -308,6 +320,238 @@ class TestHTTPBenchmarkEngine:
         # Also check that warmup did run (failed_targets cleared, query_counter reset)
         # The fake_request_single doesn't use progress, so no further checks needed.
 
+    def test_run_assertions_all_types(self):
+        """Test all assertion types supported by _run_assertions."""
+        engine = HTTPBenchmarkEngine(
+            assertions={
+                "status_code": 200,
+                "body_contains": "ok",
+                "body_regex": r"ok$",
+                "header_exists": "X-Test",
+                "header_value": {"header": "X-Test", "value": "1"},
+                "content_type": "text/html",
+                "response_size_min": 10,
+                "response_size_max": 100,
+            }
+        )
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-Test": "1", "content-type": "text/html; charset=utf-8"}
+        body = b"everything is ok"  # length 16, contains "ok"
+        results = engine._run_assertions(response, body)
+        expected = {
+            "status_code": True,
+            "body_contains": True,
+            "body_regex": True,
+            "header_exists": True,
+            "header_value": True,
+            "content_type": True,
+            "response_size_min": True,
+            "response_size_max": True,
+        }
+        assert results == expected
+
+    @pytest.mark.asyncio
+    async def test_request_single_multipart_upload(self, monkeypatch):
+        """Test the multipart upload code path (multipart_file_size > 0)."""
+        engine = HTTPBenchmarkEngine()
+        # We'll mock the client stream to return a success response.
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.is_success = True
+        fake_response.is_redirect = False
+        fake_response.http_version = "HTTP/2"
+        fake_response.headers = {}
+        fake_response.aread = AsyncMock(return_value=b"OK")
+        fake_response.history = []
+        fake_response.url = "https://example.com"
+
+        class FakeStreamContext:
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                # Capture that content was sent
+                self._sent_content = kwargs.get("content")
+                return FakeStreamContext(fake_response)
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client(url):
+            client = FakeClient()
+            return client, MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single(
+            "https://example.com", multipart_file_size=1024
+        )
+
+        # Check that we got a success result
+        assert result.status == QueryStatus.SUCCESS
+        # Verify that upload metrics were set
+        assert result.upload_size_bytes is not None and result.upload_size_bytes > 0
+        assert result.upload_time_ms is not None and result.upload_time_ms >= 0
+        assert (
+            result.upload_throughput_mbps is not None
+            and result.upload_throughput_mbps >= 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_single_connection_reuse(self, monkeypatch):
+        """Test connection reuse detection when enable_connection_reuse=True."""
+        engine = HTTPBenchmarkEngine(enable_connection_reuse=True)
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.is_success = True
+        fake_response.is_redirect = False
+        fake_response.http_version = "HTTP/2"
+        fake_response.headers = {}
+        fake_response.aread = AsyncMock(return_value=b"OK")
+        fake_response.history = []
+        fake_response.url = "https://example.com"
+        # Force fallback to transport.get_connection_metrics()
+        fake_response.extensions = {}
+
+        class FakeStreamContext:
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                return FakeStreamContext(fake_response)
+
+            async def aclose(self):
+                pass
+
+        mock_transport = MagicMock(spec=MetricsCapturingTransport)
+        mock_transport.get_connection_metrics.return_value = {
+            "connection_id": "conn-42",
+            "tcp_connect_ms": 10.0,
+        }
+
+        async def fake_get_client(url):
+            return FakeClient(), mock_transport
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        # First request: connection not reused.
+        result1 = await engine.request_single("https://example.com")
+        assert result1.connection_id == "conn-42"
+        assert result1.connection_reused is False
+
+        # Second request to same origin: should be reused.
+        result2 = await engine.request_single("https://example.com")
+        assert result2.connection_id == "conn-42"
+        assert result2.connection_reused is True
+
+    @pytest.mark.asyncio
+    async def test_request_single_generic_exception_retry(self, monkeypatch):
+        """Test that generic exceptions are retried and eventually return UNKNOWN_ERROR."""
+        engine = HTTPBenchmarkEngine(max_retries=2, retry_backoff_multiplier=0.001)
+
+        # Simulate a generic exception (not Timeout, SSL, Connect)
+        class FakeClient:
+            def __init__(self, fail_count):
+                self.fail_count = fail_count
+                self.attempt = 0
+
+            def stream(self, *args, **kwargs):
+                self.attempt += 1
+                if self.attempt <= self.fail_count:
+                    raise ValueError("Something unexpected happened")
+                # If not failing, return success
+                fake_response = MagicMock()
+                fake_response.status_code = 200
+                fake_response.is_success = True
+                fake_response.is_redirect = False
+                fake_response.http_version = "HTTP/1.1"
+                fake_response.headers = {}
+                fake_response.aread = AsyncMock(return_value=b"OK")
+                fake_response.history = []
+                fake_response.url = "https://example.com"
+                return FakeStreamContext(fake_response)
+
+            async def aclose(self):
+                pass
+
+        class FakeStreamContext:
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *args):
+                pass
+
+        async def fake_get_client(url):
+            # We need a new client per call to reset attempt counter.
+            # We'll use a closure to return a fresh client each time.
+            # Actually the engine calls _get_client once per request, so we can
+            # create a single client that tracks attempts.
+            # But we want to simulate that the first two attempts fail, third succeeds.
+            # Let's create a client with fail_count=2.
+            client = FakeClient(fail_count=2)
+            return client, MagicMock()
+
+        monkeypatch.setattr(engine, "_get_client", fake_get_client)
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        result = await engine.request_single("https://example.com")
+        # After two retries (total attempts = 3), it should succeed.
+        # But we have max_retries=2, so we have attempt 0,1,2 => 3 attempts.
+        # The client fails for first two attempts (attempt=1 and 2), succeeds on attempt=3.
+        assert result.status == QueryStatus.SUCCESS
+        assert result.attempt_number == 3  # because it succeeded on third attempt
+
+        # Now test exhaustion: set fail_count=3 so all attempts fail.
+        # We'll create a new engine and test that it returns UNKNOWN_ERROR.
+        engine2 = HTTPBenchmarkEngine(max_retries=2, retry_backoff_multiplier=0.001)
+
+        class AlwaysFailClient:
+            def __init__(self):
+                self.attempt = 0
+
+            def stream(self, *args, **kwargs):
+                self.attempt += 1
+                raise ValueError("Always failing")
+
+            async def aclose(self):
+                pass
+
+        async def fake_get_client_always_fail(url):
+            return AlwaysFailClient(), MagicMock()
+
+        monkeypatch.setattr(engine2, "_get_client", fake_get_client_always_fail)
+        monkeypatch.setattr(engine2, "_update_progress", AsyncMock())
+
+        result2 = await engine2.request_single("https://example.com")
+        assert result2.status == QueryStatus.UNKNOWN_ERROR
+        assert result2.error_message == "Always failing"
+        assert result2.attempt_number == 3  # max_retries=2, so attempt=3 (0,1,2)
+
+        # Also verify that the generic exception branch increments failed_targets.
+        # We can check engine2.failed_targets after the request.
+        assert engine2.failed_targets.get("https://example.com") == 1
+
 
 class TestTimingNetworkStream:
     @pytest.mark.asyncio
@@ -440,3 +684,444 @@ class TestParseCertDer:
         days, cn, issuer, sans, wildcard = _parse_cert_der(b"garbage")
         assert days is None
         assert cn is None
+
+
+# ---------------------------------------------------------------------------
+# PushTrackingH2Connection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _H2_AVAILABLE, reason="h2 not installed")
+class TestPushTrackingH2Connection:
+    def test_init_starts_with_no_push_promises(self):
+        conn = PushTrackingH2Connection()
+        assert conn.push_promises == []
+
+    def test_receive_data_records_pushed_stream(self, monkeypatch):
+        conn = PushTrackingH2Connection()
+
+        pushed_event = h2.events.PushedStreamReceived()
+        pushed_event.parent_stream_id = 1
+        pushed_event.pushed_stream_id = 2
+        pushed_event.headers = [
+            (b":path", b"/style.css"),
+            (b":scheme", b"https"),
+            (b":authority", b"example.com"),
+        ]
+
+        # Patch the real H2Connection.receive_data (the super() call) rather
+        # than feeding raw wire bytes through a real handshake — mirrors how
+        # http_test_core.py mocks at the httpx/httpcore boundary instead of
+        # exercising real network/protocol machinery.
+        monkeypatch.setattr(
+            "h2.connection.H2Connection.receive_data",
+            lambda self, data: [pushed_event],
+        )
+
+        events = conn.receive_data(b"irrelevant-bytes")
+
+        assert events == [pushed_event]
+        assert len(conn.push_promises) == 1
+        promise = conn.push_promises[0]
+        assert promise["stream_id"] == 1
+        assert promise["promised_stream_id"] == 2
+        assert promise["url"] == "https://example.com/style.css"
+
+    def test_receive_data_ignores_non_push_events(self, monkeypatch):
+        conn = PushTrackingH2Connection()
+        other_event = MagicMock()  # not a PushedStreamReceived
+
+        monkeypatch.setattr(
+            "h2.connection.H2Connection.receive_data",
+            lambda self, data: [other_event],
+        )
+
+        events = conn.receive_data(b"irrelevant-bytes")
+        assert events == [other_event]
+        assert conn.push_promises == []
+
+    def test_receive_data_missing_path_or_authority_falls_back_to_path(
+        self, monkeypatch
+    ):
+        """If :authority or :path is missing, url should just be the raw path
+        (possibly empty) rather than a malformed partial URL."""
+        conn = PushTrackingH2Connection()
+        pushed_event = h2.events.PushedStreamReceived()
+        pushed_event.parent_stream_id = 5
+        pushed_event.pushed_stream_id = 6
+        pushed_event.headers = [(b":path", b"/no-authority.js")]
+
+        monkeypatch.setattr(
+            "h2.connection.H2Connection.receive_data",
+            lambda self, data: [pushed_event],
+        )
+
+        conn.receive_data(b"x")
+        assert conn.push_promises[0]["url"] == "/no-authority.js"
+
+
+@pytest.mark.skipif(not _H2_AVAILABLE, reason="h2 not installed")
+class TestPushDetectingPoolInitConnection:
+    @pytest.mark.asyncio
+    async def test_init_connection_swaps_in_tracking_h2_connection(self, monkeypatch):
+        import ssl
+
+        pool = PushDetectingPool(
+            ssl_context=ssl.create_default_context(),
+            http2=True,
+            network_backend=MagicMock(),
+        )
+
+        fake_h2_conn = MagicMock()
+        fake_h2_conn.config = MagicMock()
+        fake_http_conn = MagicMock()
+        fake_http_conn._h2_connection = fake_h2_conn
+        fake_conn = MagicMock()
+        fake_conn.connection = fake_http_conn
+
+        async def fake_parent_init(self, url, ssl_context):
+            return fake_conn
+
+        # Use patch with create=True to mock the method even if it doesn't exist on the class.
+        with patch.object(
+            AsyncConnectionPool, "_init_connection", new=fake_parent_init, create=True
+        ):
+            result = await pool._init_connection(MagicMock(), MagicMock())
+
+        assert result is fake_conn
+        assert isinstance(fake_http_conn._h2_connection, PushTrackingH2Connection)
+
+    @pytest.mark.asyncio
+    async def test_init_connection_degrades_gracefully_on_missing_attr(
+        self, monkeypatch
+    ):
+        import ssl
+
+        pool = PushDetectingPool(
+            ssl_context=ssl.create_default_context(),
+            http2=True,
+            network_backend=MagicMock(),
+        )
+
+        fake_conn = MagicMock()
+        # Remove the 'connection' attribute to simulate private-API drift
+        del fake_conn.connection
+
+        async def fake_parent_init(self, url, ssl_context):
+            return fake_conn
+
+        with patch.object(
+            AsyncConnectionPool, "_init_connection", new=fake_parent_init, create=True
+        ):
+            result = await pool._init_connection(MagicMock(), MagicMock())
+
+        assert result is fake_conn
+
+
+# ---------------------------------------------------------------------------
+# get_recent_push_promises
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentPushPromises:
+    def test_disabled_returns_empty_list(self):
+        transport = MetricsCapturingTransport(verify=False, enable_push_detection=False)
+        assert transport.get_recent_push_promises() == []
+
+    @pytest.mark.skipif(not _H2_AVAILABLE, reason="h2 not installed")
+    def test_enabled_returns_promises_from_matching_connection(self):
+        transport = MetricsCapturingTransport(verify=False, http2=True)
+        transport._enable_push_detection = True
+
+        tracked = PushTrackingH2Connection()
+        tracked.push_promises = [{"stream_id": 1, "promised_stream_id": 2, "url": "x"}]
+
+        fake_http_conn = MagicMock()
+        fake_http_conn._h2_connection = tracked
+        fake_conn = MagicMock()
+        fake_conn.connection = fake_http_conn
+
+        mock_pool = MagicMock()
+        mock_pool.connections = [fake_conn]
+        transport._pool = mock_pool
+
+        result = transport.get_recent_push_promises()
+        assert result == tracked.push_promises
+
+    @pytest.mark.skipif(not _H2_AVAILABLE, reason="h2 not installed")
+    def test_enabled_skips_connections_without_h2(self):
+        transport = MetricsCapturingTransport(verify=False, http2=True)
+        transport._enable_push_detection = True
+
+        plain_http_conn = MagicMock(spec=[])  # no _h2_connection
+        fake_conn = MagicMock()
+        fake_conn.connection = plain_http_conn
+
+        mock_pool = MagicMock()
+        mock_pool.connections = [fake_conn]
+        transport._pool = mock_pool
+
+        assert transport.get_recent_push_promises() == []
+
+    def test_enabled_but_pool_access_raises_attributeerror_returns_empty(self):
+        transport = MetricsCapturingTransport(verify=False)
+        transport._enable_push_detection = True
+        transport._pool = MagicMock(
+            spec=[]
+        )  # accessing .connections raises AttributeError
+
+        assert transport.get_recent_push_promises() == []
+
+    def test_enabled_but_unexpected_error_propagates(self):
+        """A non-AttributeError bug in this loop (e.g. TypeError from a
+        code change) must NOT be silently swallowed — only private-API
+        shape drift (AttributeError) should degrade to an empty list."""
+        transport = MetricsCapturingTransport(verify=False)
+        transport._enable_push_detection = True
+
+        class BoomConnections:
+            def __iter__(self):
+                raise TypeError("boom")
+
+        transport._pool = MagicMock()
+        transport._pool.connections = BoomConnections()
+
+        with pytest.raises(TypeError, match="boom"):
+            transport.get_recent_push_promises()
+
+
+# ---------------------------------------------------------------------------
+# HTTPDigestAuth
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPDigestAuth:
+    def _make_request(self, method="GET", url="https://example.com/secure"):
+        return httpx.Request(method, url)
+
+    def _make_401(self, www_authenticate: str):
+        return httpx.Response(
+            401,
+            headers={"www-authenticate": www_authenticate},
+            request=httpx.Request("GET", "https://example.com/secure"),
+        )
+
+    def test_parse_challenge_extracts_all_fields(self):
+        auth = HTTPDigestAuth("user", "pass")
+        challenge = auth._parse_challenge(
+            'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5, opaque="xyz"'
+        )
+        assert challenge["realm"] == "test"
+        assert challenge["nonce"] == "abc123"
+        assert challenge["qop"] == "auth"
+        assert challenge["algorithm"] == "MD5"
+        assert challenge["opaque"] == "xyz"
+
+    def test_auth_flow_non_401_response_does_nothing(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request()
+        flow = auth.auth_flow(request)
+        first = next(flow)
+        assert first is request
+
+        ok_response = httpx.Response(200, request=request)
+        with pytest.raises(StopIteration):
+            flow.send(ok_response)
+
+    def test_auth_flow_non_digest_challenge_does_nothing(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request()
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        response = self._make_401('Basic realm="test"')
+        with pytest.raises(StopIteration):
+            flow.send(response)
+
+    def test_auth_flow_missing_nonce_does_nothing(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request()
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        response = self._make_401('Digest realm="test"')
+        with pytest.raises(StopIteration):
+            flow.send(response)
+
+    def test_auth_flow_with_qop_sets_authorization_header(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request(method="GET", url="https://example.com/secure")
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        response = self._make_401(
+            'Digest realm="testrealm", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '
+            'qop="auth", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+        )
+        second_request = flow.send(response)
+
+        auth_header = second_request.headers["Authorization"]
+        assert auth_header.startswith("Digest ")
+        assert 'username="user"' in auth_header
+        assert 'realm="testrealm"' in auth_header
+        assert "qop=auth" in auth_header
+        assert "nc=00000001" in auth_header
+        assert "cnonce=" in auth_header
+        assert 'response="' in auth_header
+
+        with pytest.raises(StopIteration):
+            flow.send(httpx.Response(200, request=second_request))
+
+    def test_auth_flow_without_qop_uses_legacy_response_formula(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request()
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        response = self._make_401('Digest realm="testrealm", nonce="abc123"')
+        second_request = flow.send(response)
+        auth_header = second_request.headers["Authorization"]
+
+        # Legacy path must NOT include qop/nc/cnonce.
+        assert "qop=" not in auth_header
+        assert "nc=" not in auth_header
+        assert "cnonce=" not in auth_header
+        assert 'response="' in auth_header
+
+    def test_auth_flow_sha256_algorithm_selected(self):
+        auth = HTTPDigestAuth("user", "pass")
+        request = self._make_request()
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        response = self._make_401(
+            'Digest realm="testrealm", nonce="abc123", algorithm=SHA-256, qop="auth"'
+        )
+        second_request = flow.send(response)
+        assert "algorithm=SHA-256" in second_request.headers["Authorization"]
+
+    def test_nonce_count_increments_across_multiple_challenges(self):
+        auth = HTTPDigestAuth("user", "pass")
+        assert auth._nonce_count == 0
+
+        for _ in range(2):
+            request = self._make_request()
+            flow = auth.auth_flow(request)
+            next(flow)
+            response = self._make_401('Digest realm="r", nonce="n", qop="auth"')
+            flow.send(response)
+            with pytest.raises(StopIteration):
+                flow.send(httpx.Response(200, request=request))
+
+        assert auth._nonce_count == 2
+
+
+# ---------------------------------------------------------------------------
+# HTTPBenchmarkEngine.websocket_single
+# ---------------------------------------------------------------------------
+
+
+class TestWebsocketSingle:
+    @pytest.mark.asyncio
+    async def test_websocket_single_raises_if_aiohttp_unavailable(self, monkeypatch):
+        monkeypatch.setattr("net_benchmark.http_bench.core._AIOHTTP_AVAILABLE", False)
+        engine = HTTPBenchmarkEngine()
+        with pytest.raises(ImportError, match="aiohttp"):
+            await engine.websocket_single("wss://example.com/ws")
+
+    @pytest.mark.skipif(not _AIOHTTP_AVAILABLE, reason="aiohttp not installed")
+    @pytest.mark.asyncio
+    async def test_websocket_single_success(self, monkeypatch):
+        engine = HTTPBenchmarkEngine()
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        fake_ws = MagicMock()
+
+        class FakeWSContext:
+            async def __aenter__(self):
+                return fake_ws
+
+            async def __aexit__(self, *args):
+                return False
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def ws_connect(self, target):
+                return FakeWSContext()
+
+        with patch(
+            "net_benchmark.http_bench.core.aiohttp.ClientSession",
+            return_value=FakeSession(),
+        ):
+            result = await engine.websocket_single("wss://example.com/ws", iteration=2)
+
+        assert result.status == QueryStatus.SUCCESS
+        assert result.iteration == 2
+        assert result.websocket_handshake_ms is not None
+        assert result.websocket_handshake_ms >= 0
+        assert result.total_ms == pytest.approx(result.websocket_handshake_ms)
+
+    @pytest.mark.skipif(not _AIOHTTP_AVAILABLE, reason="aiohttp not installed")
+    @pytest.mark.asyncio
+    async def test_websocket_single_connection_failure(self, monkeypatch):
+        engine = HTTPBenchmarkEngine()
+        monkeypatch.setattr(engine, "_update_progress", AsyncMock())
+
+        class FailingSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def ws_connect(self, target):
+                raise ConnectionRefusedError("refused")
+
+        with patch(
+            "net_benchmark.http_bench.core.aiohttp.ClientSession",
+            return_value=FailingSession(),
+        ):
+            result = await engine.websocket_single("wss://down.example.com/ws")
+
+        assert result.status == QueryStatus.UNKNOWN_ERROR
+        assert "refused" in result.error_message
+        assert result.websocket_handshake_ms is None
+
+    @pytest.mark.skipif(not _AIOHTTP_AVAILABLE, reason="aiohttp not installed")
+    @pytest.mark.asyncio
+    async def test_websocket_single_calls_update_progress(self, monkeypatch):
+        """Progress tracking must fire on both success and failure paths,
+        same as request_single — otherwise progress bars stall silently."""
+        engine = HTTPBenchmarkEngine()
+        progress_mock = AsyncMock()
+        monkeypatch.setattr(engine, "_update_progress", progress_mock)
+
+        class FakeWSContext:
+            async def __aenter__(self):
+                return MagicMock()
+
+            async def __aexit__(self, *args):
+                return False
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def ws_connect(self, target):
+                return FakeWSContext()
+
+        with patch(
+            "net_benchmark.http_bench.core.aiohttp.ClientSession",
+            return_value=FakeSession(),
+        ):
+            await engine.websocket_single("wss://example.com/ws")
+
+        progress_mock.assert_awaited_once()

--- a/src/net_benchmark/http_bench/tests/test_load_test.py
+++ b/src/net_benchmark/http_bench/tests/test_load_test.py
@@ -1,0 +1,304 @@
+"""Unit tests for the load test engine (load_test.py)."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from net_benchmark.http_bench.core import HTTPResult, QueryStatus
+from net_benchmark.http_bench.load_test import (
+    LoadTestEngine,
+    LoadTestMode,
+    _build_intervals,
+    _summarize,
+    _TimedResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helper to create a fake HTTPResult
+# ---------------------------------------------------------------------------
+
+
+def fake_result(
+    total_ms: float = 100.0, status: QueryStatus = QueryStatus.SUCCESS
+) -> HTTPResult:
+    """Build a minimal HTTPResult for load-test engine tests."""
+    now = time.time()
+    return HTTPResult(
+        target="https://example.com",
+        method="GET",
+        start_time=now,
+        end_time=now + total_ms / 1000.0,
+        total_ms=total_ms,
+        status=status,
+        iteration=1,
+        http_status_code=200 if status == QueryStatus.SUCCESS else 500,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_empty_timed_results(self):
+        assert _build_intervals([]) == []
+
+    def test_single_bucket(self):
+        r = fake_result(100.0)
+        tr = _TimedResult(result=r, completed_at_offset_s=0.5)
+        intervals = _build_intervals([tr])
+        assert len(intervals) == 1
+        assert intervals[0].window_index == 0
+        assert intervals[0].stats.total_requests == 1
+
+    def test_multiple_buckets(self):
+        results = [
+            _TimedResult(fake_result(100.0), 0.3),
+            _TimedResult(fake_result(200.0), 1.2),
+            _TimedResult(fake_result(150.0), 2.7),
+        ]
+        intervals = _build_intervals(results, bucket_s=1.0)
+        assert len(intervals) == 3
+        assert intervals[0].window_index == 0
+        assert intervals[0].stats.total_requests == 1
+        assert intervals[1].window_index == 1
+        assert intervals[1].stats.total_requests == 1
+        assert intervals[2].window_index == 2
+        assert intervals[2].stats.total_requests == 1
+
+    def test_empty_summarize(self):
+        summary = _summarize(
+            mode=LoadTestMode.THROUGHPUT,
+            target="https://example.com",
+            duration_s=1.0,
+            timed_results=[],
+            target_rps=None,
+            connections_opened=0,
+        )
+        assert summary.stats.total_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for LoadTestEngine
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTestEngine:
+    @pytest.fixture
+    def mock_engine(self, monkeypatch):
+        """Replace HTTPBenchmarkEngine in load_test with a fully controllable mock."""
+        instance = MagicMock()
+        instance.request_single = AsyncMock()
+        instance.close = AsyncMock()
+        instance.get_connection_stats = MagicMock(
+            return_value={"connections_opened": 2}
+        )
+
+        # Patch the class inside load_test.py so LoadTestEngine gets our mock
+        monkeypatch.setattr(
+            "net_benchmark.http_bench.load_test.HTTPBenchmarkEngine",
+            MagicMock(return_value=instance),
+        )
+        return instance
+
+    @pytest.mark.asyncio
+    async def test_throughput_normal(self, mock_engine):
+        call_count = 0
+
+        async def request_single(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return fake_result(100.0 + call_count)
+
+        mock_engine.request_single.side_effect = request_single
+
+        engine = LoadTestEngine("https://example.com")
+        summary = await engine.run_throughput(duration_s=1.0, max_concurrency=10)
+
+        assert summary.mode == LoadTestMode.THROUGHPUT
+        assert summary.stats.total_requests > 0
+        assert summary.achieved_rps > 0
+        assert summary.connection_reuse.connections_opened == 2
+        await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_sustained_mode(self, mock_engine):
+        target_rps = 50
+        duration_s = 1.0
+
+        async def fast_response(*args, **kwargs):
+            return fake_result(10.0)
+
+        mock_engine.request_single.side_effect = fast_response
+
+        engine = LoadTestEngine("https://example.com")
+        summary = await engine.run_sustained(
+            target_rps=target_rps, duration_s=duration_s
+        )
+
+        assert summary.mode == LoadTestMode.SUSTAINED
+        assert abs(summary.achieved_rps - target_rps) < target_rps * 0.2
+        assert summary.target_rps == target_rps
+
+    @pytest.mark.asyncio
+    async def test_sustained_zero_rps_raises(self, mock_engine):
+        engine = LoadTestEngine("https://example.com")
+        with pytest.raises(ValueError, match="target_rps must be > 0"):
+            await engine.run_sustained(target_rps=0, duration_s=1.0)
+
+    @pytest.mark.asyncio
+    async def test_ramp_up_mode(self, mock_engine):
+        async def slow_response(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return fake_result(50.0)
+
+        mock_engine.request_single.side_effect = slow_response
+
+        engine = LoadTestEngine("https://example.com")
+        summary = await engine.run_ramp_up(
+            start_concurrency=1,
+            max_concurrency=5,
+            ramp_duration_s=2.0,
+            hold_duration_s=1.0,
+        )
+        assert summary.mode == LoadTestMode.RAMP_UP
+        assert summary.stats.total_requests > 0
+
+    @pytest.mark.asyncio
+    async def test_ramp_up_invalid_args(self, mock_engine):
+        engine = LoadTestEngine("https://example.com")
+        with pytest.raises(ValueError):
+            await engine.run_ramp_up(
+                start_concurrency=0, max_concurrency=10, ramp_duration_s=1
+            )
+        with pytest.raises(ValueError):
+            await engine.run_ramp_up(
+                start_concurrency=10, max_concurrency=5, ramp_duration_s=1
+            )
+
+    @pytest.mark.asyncio
+    async def test_engine_close(self, mock_engine):
+        engine = LoadTestEngine("https://example.com")
+        await engine.close()
+        mock_engine.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connections_opened(self, mock_engine):
+        engine = LoadTestEngine("https://example.com")
+        opened = await engine._connections_opened()
+        assert opened == 2
+        mock_engine.get_connection_stats.assert_called_once_with("https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_intervals_populated(self, mock_engine):
+        async def response_with_delay(*args, **kwargs):
+            await asyncio.sleep(0.1)
+            return fake_result(50.0)
+
+        mock_engine.request_single.side_effect = response_with_delay
+
+        engine = LoadTestEngine("https://example.com")
+        summary = await engine.run_throughput(duration_s=0.5, max_concurrency=5)
+        assert len(summary.intervals) > 0
+
+    @pytest.mark.asyncio
+    async def test_ramp_up_max_total_rps_ceiling(self, mock_engine):
+        """Instant-response mock + a low max_total_rps should keep achieved
+        RPS near the ceiling instead of exploding, proving the shared
+        token bucket in slot_worker actually throttles aggregate rate."""
+
+        async def instant_response(*args, **kwargs):
+            return fake_result(1.0)
+
+        mock_engine.request_single.side_effect = instant_response
+
+        engine = LoadTestEngine("https://example.com")
+        summary = await engine.run_ramp_up(
+            start_concurrency=5,
+            max_concurrency=20,
+            ramp_duration_s=0.5,
+            hold_duration_s=0.5,
+            max_total_rps=50,
+        )
+
+        # Allow generous slack for scheduling jitter over a ~1s run —
+        # this asserts "bounded near the ceiling", not "exactly 50".
+        assert summary.achieved_rps < 50 * 1.5
+        assert summary.stats.total_requests > 0
+
+
+class TestLoadTestSummaryToDict:
+    def test_to_dict_structure(self):
+        r1 = fake_result(100.0, QueryStatus.SUCCESS)
+        r2 = fake_result(200.0, QueryStatus.TIMEOUT)
+        timed_results = [
+            _TimedResult(r1, 0.2),
+            _TimedResult(r2, 0.4),
+        ]
+        summary = _summarize(
+            mode=LoadTestMode.SUSTAINED,
+            target="https://example.com",
+            duration_s=1.0,
+            timed_results=timed_results,
+            target_rps=50.0,
+            connections_opened=2,
+        )
+
+        d = summary.to_dict()
+
+        # Top-level scalar fields
+        assert d["mode"] == "sustained"  # enum -> .value, not the Enum member
+        assert d["target"] == "https://example.com"
+        assert d["duration_s"] == 1.0
+        assert d["target_rps"] == 50.0
+        assert d["achieved_rps"] == summary.achieved_rps
+
+        # stats: vars(TargetStats) -> plain dict
+        assert isinstance(d["stats"], dict)
+        assert d["stats"]["total_requests"] == 2
+
+        # status_code_distribution passed through as-is
+        assert isinstance(d["status_code_distribution"], list)
+
+        # connection_reuse: hand-built dict, not vars(dataclass), so check
+        # each derived property was materialized as a plain value
+        conn = d["connection_reuse"]
+        assert conn["total_requests"] == 2
+        assert conn["connections_opened"] == 2
+        assert conn["connections_reused"] == summary.connection_reuse.connections_reused
+        assert conn["reuse_rate"] == pytest.approx(summary.connection_reuse.reuse_rate)
+
+        # intervals: list of dicts, each with vars(stats) nested
+        assert isinstance(d["intervals"], list)
+        assert len(d["intervals"]) == len(summary.intervals)
+        for iv_dict, iv in zip(d["intervals"], summary.intervals):
+            assert iv_dict["window_index"] == iv.window_index
+            assert isinstance(iv_dict["stats"], dict)
+            assert iv_dict["status_code_distribution"] == iv.status_code_distribution
+
+    def test_to_dict_empty_summary_is_json_safe(self):
+        summary = _summarize(
+            mode=LoadTestMode.THROUGHPUT,
+            target="https://example.com",
+            duration_s=1.0,
+            timed_results=[],
+            target_rps=None,
+            connections_opened=0,
+        )
+
+        d = summary.to_dict()
+
+        assert d["target_rps"] is None
+        assert d["achieved_rps"] == 0.0
+        assert d["intervals"] == []
+        assert d["stats"]["total_requests"] == 0
+
+        # Round-trips through json without error (this is what JSON export
+        # actually relies on) — enums, dataclasses, etc. must already be
+        # plain values by the time to_dict() returns.
+        import json
+
+        json.dumps(d)

--- a/src/net_benchmark/http_bench/tests/test_load_test_exporters.py
+++ b/src/net_benchmark/http_bench/tests/test_load_test_exporters.py
@@ -1,0 +1,314 @@
+"""Unit tests for load_test_exporters.py."""
+
+import json
+import os
+
+import pandas as pd
+import pytest
+
+from net_benchmark.http_bench.core import HTTPProtocol, HTTPResult, QueryStatus
+from net_benchmark.http_bench.load_test import LoadTestMode, _summarize, _TimedResult
+from net_benchmark.http_bench.load_test_exporters import (
+    LoadTestCSVExporter,
+    LoadTestExcelExporter,
+    LoadTestExportBundle,
+    LoadTestPDFExporter,
+    _sheet_name,
+    combined_error_breakdown,
+    error_breakdown,
+)
+
+try:
+    from weasyprint import HTML
+except ImportError:
+    HTML = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers — same fake_result shape as http_test_load_test.py
+# ---------------------------------------------------------------------------
+
+
+def fake_result(
+    target: str = "https://example.com",
+    total_ms: float = 100.0,
+    status: QueryStatus = QueryStatus.SUCCESS,
+    error_message: str = None,
+) -> HTTPResult:
+    """Return a minimal HTTPResult with a valid protocol so HTTPAnalyzer
+    doesn't crash on r.protocol.value."""
+    return HTTPResult(
+        target=target,
+        method="GET",
+        start_time=1.0,
+        end_time=1.0 + total_ms / 1000.0,
+        total_ms=total_ms,
+        status=status,
+        iteration=1,
+        http_status_code=200 if status == QueryStatus.SUCCESS else 500,
+        error_message=error_message,
+        protocol=HTTPProtocol.HTTP2,
+        connection_id="conn-1",
+        tls_resumed=False,
+    )
+
+
+def make_summary(
+    target: str = "https://example.com",
+    mode: LoadTestMode = LoadTestMode.THROUGHPUT,
+    n_success: int = 8,
+    n_fail: int = 2,
+    target_rps: float = None,
+    connections_opened: int = 3,
+):
+    """Build a real LoadTestSummary via _summarize."""
+    timed = []
+    offset = 0.0
+    for i in range(n_success):
+        r = fake_result(target=target, total_ms=50.0 + i, status=QueryStatus.SUCCESS)
+        timed.append(_TimedResult(r, offset))
+        offset += 0.3
+    for i in range(n_fail):
+        r = fake_result(
+            target=target,
+            total_ms=999.0,
+            status=QueryStatus.TIMEOUT,
+            error_message="Request timeout",
+        )
+        timed.append(_TimedResult(r, offset))
+        offset += 0.3
+
+    return _summarize(
+        mode=mode,
+        target=target,
+        duration_s=max(offset, 1.0),
+        timed_results=timed,
+        target_rps=target_rps,
+        connections_opened=connections_opened,
+    )
+
+
+@pytest.fixture
+def summary_a():
+    return make_summary(target="https://a.com")
+
+
+@pytest.fixture
+def summary_b():
+    return make_summary(
+        target="https://b.com", mode=LoadTestMode.SUSTAINED, target_rps=100.0
+    )
+
+
+@pytest.fixture
+def summaries(summary_a, summary_b):
+    return [summary_a, summary_b]
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestSheetName:
+    def test_strips_scheme_and_invalid_chars(self):
+        name = _sheet_name("https://a.com:8443/path?x=1")
+        assert ":" not in name
+        assert "/" not in name
+        assert "?" not in name
+
+    def test_truncates_to_31_minus_suffix(self):
+        long_target = "https://" + "x" * 50 + ".com"
+        name = _sheet_name(long_target, suffix=" Raw")
+        assert len(name) <= 31
+
+    def test_dedupes_against_used_set(self):
+        used = set()
+        n1 = _sheet_name("https://samehost.com", suffix=" Raw", used=used)
+        n2 = _sheet_name("https://samehost.com", suffix=" Raw", used=used)
+        assert n1 != n2
+        assert n1 in used and n2 in used
+
+    def test_no_used_set_returns_raw_name(self):
+        name = _sheet_name("https://x.com")
+        assert name == "x.com"
+
+
+class TestErrorBreakdown:
+    def test_error_breakdown_counts_by_message(self, summary_a):
+        counts = error_breakdown(summary_a)
+        assert counts.get("Request timeout") == 2
+
+    def test_error_breakdown_falls_back_to_status_code(self):
+        summary = make_summary(n_success=0, n_fail=0)
+        r = fake_result(status=QueryStatus.UNKNOWN_ERROR, error_message=None)
+        summary.results.append(r)
+        counts = error_breakdown(summary)
+        assert "HTTP 500" in counts
+
+    def test_combined_error_breakdown_sums_across_targets(self, summaries):
+        combined = combined_error_breakdown(summaries)
+        assert combined["Request timeout"] == 4
+
+
+# ---------------------------------------------------------------------------
+# JSON bundle
+# ---------------------------------------------------------------------------
+
+
+class TestExportBundle:
+    def test_export_json_structure(self, tmp_path, summaries):
+        path = tmp_path / "bundle.json"
+        LoadTestExportBundle.export_json(summaries, str(path))
+        assert path.exists()
+        with open(path) as f:
+            data = json.load(f)
+        assert len(data["targets"]) == 2
+        assert data["targets"][0]["target"] == "https://a.com"
+        assert "combined_error_breakdown" in data
+        assert data["combined_error_breakdown"]["Request timeout"] == 4
+        assert "generated_at" in data
+
+    def test_export_json_round_trips_enums(self, tmp_path, summary_a):
+        path = tmp_path / "bundle.json"
+        LoadTestExportBundle.export_json([summary_a], str(path))
+        with open(path) as f:
+            json.load(f)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class TestCSVExporter:
+    def test_export_raw_results(self, tmp_path, summaries):
+        path = tmp_path / "raw.csv"
+        LoadTestCSVExporter.export_raw_results(summaries, str(path))
+        df = pd.read_csv(path)
+        total_results = sum(len(s.results) for s in summaries)
+        assert len(df) == total_results
+        assert "load_test_mode" in df.columns
+        assert set(df["load_test_mode"].unique()) == {"throughput", "sustained"}
+
+    def test_export_summary(self, tmp_path, summaries):
+        path = tmp_path / "summary.csv"
+        LoadTestCSVExporter.export_summary(summaries, str(path))
+        df = pd.read_csv(path)
+        assert len(df) == 2
+        assert "achieved_rps" in df.columns
+        assert "connection_reuse_rate_pct" in df.columns
+        assert pd.isna(df.loc[df["target"] == "https://a.com", "target_rps"].iloc[0])
+        assert df.loc[df["target"] == "https://b.com", "target_rps"].iloc[0] == 100.0
+
+    def test_export_intervals(self, tmp_path, summaries):
+        path = tmp_path / "intervals.csv"
+        LoadTestCSVExporter.export_intervals(summaries, str(path))
+        df = pd.read_csv(path)
+        assert len(df) > 0
+        assert "window_index" in df.columns
+        assert "error_count" in df.columns
+
+    def test_export_intervals_empty_when_no_intervals(self, tmp_path):
+        empty_summary = make_summary(n_success=0, n_fail=0)
+        path = tmp_path / "intervals_empty.csv"
+        LoadTestCSVExporter.export_intervals([empty_summary], str(path))
+        # Exporting an empty intervals list produces an empty CSV with no columns.
+        # Check that the file was created and has no data (or minimal header).
+        assert os.path.exists(path)
+        with open(path) as f:
+            content = f.read().strip()
+        # Either empty or just a header line without data.
+        assert content == "" or content == "target,window_index,..."  # adjust as needed
+
+    def test_export_error_breakdown(self, tmp_path, summaries):
+        path = tmp_path / "errors.csv"
+        LoadTestCSVExporter.export_error_breakdown(summaries, str(path))
+        df = pd.read_csv(path)
+        assert set(df["target"].unique()) == {"https://a.com", "https://b.com"}
+        assert (df["error_message"] == "Request timeout").all()
+        assert (df["count"] == 2).all()
+
+
+# ---------------------------------------------------------------------------
+# Excel
+# ---------------------------------------------------------------------------
+
+
+class TestExcelExporter:
+    def test_export_results_no_charts(self, tmp_path, summaries):
+        path = tmp_path / "report.xlsx"
+        LoadTestExcelExporter.export_results(summaries, str(path), include_charts=False)
+        assert os.path.exists(path)
+
+    def test_export_results_with_charts(self, tmp_path, summaries):
+        path = tmp_path / "report_charts.xlsx"
+        LoadTestExcelExporter.export_results(summaries, str(path), include_charts=True)
+        assert os.path.exists(path)
+
+    def test_export_results_cleans_up_temp_charts(
+        self, tmp_path, summaries, monkeypatch
+    ):
+        created_dirs = []
+        import net_benchmark.http_bench.load_test_exporters as lte
+
+        orig_mkdtemp = lte.tempfile.mkdtemp
+
+        def spy_mkdtemp(*a, **kw):
+            d = orig_mkdtemp(*a, **kw)
+            created_dirs.append(d)
+            return d
+
+        monkeypatch.setattr(lte.tempfile, "mkdtemp", spy_mkdtemp)
+
+        path = tmp_path / "report_cleanup.xlsx"
+        LoadTestExcelExporter.export_results(summaries, str(path), include_charts=True)
+
+        assert created_dirs, "expected mkdtemp to be called for chart generation"
+        for d in created_dirs:
+            assert not os.path.exists(d) or os.listdir(d) == []
+
+    def test_sheet_names_deduped_across_multiple_targets_with_same_host(self, tmp_path):
+        long_prefix = "https://" + "verylonghostnameexample" * 2 + "-a.com"
+        s1 = make_summary(target=long_prefix + "1")
+        s2 = make_summary(target=long_prefix + "2")
+        path = tmp_path / "dedup.xlsx"
+        LoadTestExcelExporter.export_results([s1, s2], str(path), include_charts=False)
+        assert os.path.exists(path)
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(HTML is None, reason="weasyprint not installed")
+class TestPDFExporter:
+    def test_export_results_no_charts(self, tmp_path, summaries):
+        path = tmp_path / "report.pdf"
+        LoadTestPDFExporter.export_results(summaries, str(path), include_charts=False)
+        assert os.path.exists(path)
+
+    def test_export_results_with_charts(self, tmp_path, summaries):
+        path = tmp_path / "report_charts.pdf"
+        LoadTestPDFExporter.export_results(summaries, str(path), include_charts=True)
+        assert os.path.exists(path)
+
+    def test_export_results_no_intervals_skips_timeline_charts(self, tmp_path):
+        empty_summary = make_summary(n_success=0, n_fail=0)
+        path = tmp_path / "no_intervals.pdf"
+        LoadTestPDFExporter.export_results(
+            [empty_summary], str(path), include_charts=True
+        )
+        assert os.path.exists(path)
+
+
+class TestPDFExporterMissingDependency:
+    def test_raises_when_weasyprint_unavailable(self, tmp_path, summaries, monkeypatch):
+        import net_benchmark.http_bench.load_test_exporters as lte
+
+        monkeypatch.setattr(lte, "HTML", None)
+        with pytest.raises(RuntimeError, match="weasyprint"):
+            LoadTestPDFExporter.export_results(
+                summaries, str(tmp_path / "x.pdf"), include_charts=False
+            )


### PR DESCRIPTION
…-up modes

implement the http load testing framework for the net-benchmark suite, providing three distinct execution modes and advanced connection-level metrics.

new features:
- `load_test.py` – core load test orchestrator:
  - throughput mode: saturate the target with as many requests as possible.
  - sustained mode: maintain a fixed requests-per-second rate.
  - ramp-up mode: gradually increase concurrency from start to peak.
  - safety ceilings for ramp-up to prevent overload.
- `load_test_exporters.py` – export results to:
  - csv (raw data and summary)
  - excel (with optional charts)
  - pdf (report with summary statistics)
- cli integration (`http load-test` command) with all necessary options.
- advanced detection features (optional):
  - connection reuse tracking (`--enable-connection-reuse`)
  - tls session resumption detection (`--enable-tls-resumption`)
  - http/2 server push detection (`--enable-push-detection`)

improvements & fixes:
- `core.py`: add per‑connection metrics and multipart upload timing.
- `analysis.py`: support the new export formats.
- enhance test coverage:
  - new unit tests for load test engine and exporters.
  - extended core tests for multipart upload, connection reuse, and generic exceptions.

docs:
- add "no paid work or crypto offers" section to `contributing.md`.
- update `.gitignore` entries for generated output directories.