### PR TITLE
Fix unspecified encoding (ruff rule PLW1514)

### DIFF
--- a/src/net_benchmark/dns_benchmark/cli.py
+++ b/src/net_benchmark/dns_benchmark/cli.py
@@ -709,13 +709,13 @@ def top(
                         for i, (name, stats, score) in enumerate(top_resolvers)
                     ],
                 }
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(export_data, f, indent=2)
 
             elif ext == ".csv":
                 import csv
 
-                with open(output_path, "w", newline="") as f:
+                with open(output_path, "w", encoding="utf-8", newline="") as f:
                     writer = csv.writer(f)
                     writer.writerow(
                         [
@@ -744,7 +744,7 @@ def top(
                         )
 
             else:  # .txt or default
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     f.write(f"Top {len(top_resolvers)} DNS Resolvers (by {metric})\n")
                     f.write(
                         f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
@@ -1068,7 +1068,7 @@ def compare(
                         for name, stats in resolver_stats.items()
                     ],
                 }
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(export_data, f, indent=2)
             else:
                 CSVExporter.export_summary_statistics(analyzer, str(output_path))
@@ -1210,7 +1210,7 @@ def monitoring(
 
     log_file = None
     if output:
-        log_file = open(output, "a")
+        log_file = open(output, "a", encoding="utf-8")
         log_file.write(f"\n{'=' * 60}\n")
         log_file.write(
             f"Monitoring started: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
@@ -1642,7 +1642,7 @@ settings:
 
     if output:
         try:
-            with open(output, "w") as f:
+            with open(output, "w", encoding="utf-8") as f:
                 f.write(config_yaml)
             click.echo(success(f"Configuration saved to: {output}"))
         except Exception as e:

--- a/src/net_benchmark/dns_benchmark/core.py
+++ b/src/net_benchmark/dns_benchmark/core.py
@@ -1549,7 +1549,7 @@ class ResolverManager:
     @staticmethod
     def load_resolvers_from_file(file_path: str) -> List[Dict[str, str]]:
         """Load resolvers from JSON file."""
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             data: Dict[str, Any] = json.load(f)
         return cast(List[Dict[str, str]], data.get("resolvers", []))
 
@@ -2137,7 +2137,7 @@ class DomainManager:
     @staticmethod
     def load_domains_from_file(file_path: str) -> List[str]:
         """Load domains from text file (one per line)."""
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             domains = [
                 line.strip() for line in f if line.strip() and not line.startswith("#")
             ]

--- a/src/net_benchmark/dns_benchmark/exporters.py
+++ b/src/net_benchmark/dns_benchmark/exporters.py
@@ -63,7 +63,7 @@ class ExportBundle:
             "record_type_stats": record_type_stats,
             "error_stats": error_stats,
         }
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             import json
 
             json.dump(payload, f, indent=2)

--- a/src/net_benchmark/dns_benchmark/tests/test_benchmark_cli.py
+++ b/src/net_benchmark/dns_benchmark/tests/test_benchmark_cli.py
@@ -295,7 +295,7 @@ def test_benchmark_exports_csv_excel_pdf_json(tmp_path, sample_results):
         pytest.skip("weasyprint not installed; skipping PDF export check")
 
     # Validate JSON structure
-    data = json.loads(Path(json_path).read_text())
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
     assert "overall" in data
     assert isinstance(data["resolver_stats"], list)
     assert isinstance(data["raw_results"], list)

--- a/src/net_benchmark/http_bench/cli.py
+++ b/src/net_benchmark/http_bench/cli.py
@@ -1037,7 +1037,7 @@ def monitoring(
                 output_path
                 / f"http_monitor_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
             )
-            with open(snapshot_path, "w") as f:
+            with open(snapshot_path, "w", encoding="utf-8") as f:
                 json.dump(
                     {"timestamp": datetime.now().isoformat(), "overall": overall},
                     f,
@@ -1361,12 +1361,12 @@ def compare(
                         for s in target_stats
                     ],
                 }
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2)
             elif ext == ".csv":
                 HTTPCSVExporter.export_summary_statistics(analyzer, str(output_path))
             else:  # .txt
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     f.write("HTTP Target Comparison\n")
                     f.write(
                         f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"

--- a/src/net_benchmark/http_bench/core.py
+++ b/src/net_benchmark/http_bench/core.py
@@ -888,7 +888,7 @@ class TargetManager:
 
     @staticmethod
     def _load_from_file(file_path: str) -> List[str]:
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             return [
                 line.strip() for line in f if line.strip() and not line.startswith("#")
             ]

--- a/src/net_benchmark/http_bench/exporters.py
+++ b/src/net_benchmark/http_bench/exporters.py
@@ -89,7 +89,7 @@ class HTTPExportBundle:
             "error_stats": analyzer.get_error_statistics(),
             "raw_results": [r.to_dict() for r in results],
         }
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2, default=str)
 
 

--- a/src/net_benchmark/http_bench/load_test_exporters.py
+++ b/src/net_benchmark/http_bench/load_test_exporters.py
@@ -296,7 +296,7 @@ class LoadTestExportBundle:
             "combined_error_breakdown": combined_error_breakdown(summaries),
             "generated_at": datetime.now().isoformat(),
         }
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2, default=str)
 
 

--- a/src/net_benchmark/http_bench/tests/test_exporters.py
+++ b/src/net_benchmark/http_bench/tests/test_exporters.py
@@ -64,7 +64,7 @@ class TestJSONExport:
         assert os.path.exists(path)
         import json
 
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         assert "overall" in data
         assert "target_stats" in data

--- a/src/net_benchmark/http_bench/tests/test_load_test_exporters.py
+++ b/src/net_benchmark/http_bench/tests/test_load_test_exporters.py
@@ -161,7 +161,7 @@ class TestExportBundle:
         path = tmp_path / "bundle.json"
         LoadTestExportBundle.export_json(summaries, str(path))
         assert path.exists()
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         assert len(data["targets"]) == 2
         assert data["targets"][0]["target"] == "https://a.com"
@@ -172,7 +172,7 @@ class TestExportBundle:
     def test_export_json_round_trips_enums(self, tmp_path, summary_a):
         path = tmp_path / "bundle.json"
         LoadTestExportBundle.export_json([summary_a], str(path))
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             json.load(f)  # no exception
 
 
@@ -216,7 +216,7 @@ class TestCSVExporter:
         # Exporting an empty intervals list produces an empty CSV with no columns.
         # Check that the file was created and has no data (or minimal header).
         assert os.path.exists(path)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             content = f.read().strip()
         # Either empty or just a header line without data.
         assert content == "" or content == "target,window_index,..."  # adjust as needed


### PR DESCRIPTION
## Add explicit `encoding="utf-8"` to all file I/O

On Windows with a non-UTF-8 system locale (e.g. `cp1251` for Cyrillic languages), `open()` without an explicit `encoding` falls back to the platform's default encoding, which breaks on characters outside that encoding.

Concretely, `dns monitoring` crashes as soon as an alert fires, since the log file is opened without `encoding="utf-8"` and alerts contain emoji (`⚠️`):

`Error during monitoring: 'charmap' codec can't encode characters in position 18-19: character maps to <undefined>`


**Found while running `net-benchmark dns monitoring --use-defaults --dot --interval 30 --duration 3600 --alert-latency 150 --output monitor.log` from README.md on Windows 10 with a cp1251 system encoding.**

## Fix:

Added `encoding="utf-8"` to all `open()` calls across the codebase, split into two commits:

1. e24329d Production code (exporters, config/resolver/domain loaders, monitoring log)
2. bc072bb Tests

Found the remaining occurrences with ruff's [`unspecified-encoding (PLW1514)'](https://docs.astral.sh/ruff/rules/unspecified-encoding/) rule:

```bash
ruff check --select PLW1514 --preview src/
```