### PR TITLE
docs: remove stale 'What's new in 0.5.2' callout

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -64,22 +64,6 @@ net-benchmark http load-test -t https://checkout.example.com/api/cart \
   --threshold 'p95_latency<400'
 ```
 
-### Novità della 0.5.2
-
-**Test di carico distribuito.** Un singolo processo Python è di norma il collo
-di bottiglia molto prima del tuo target. `--workers N` genera il carico da N
-processi separati con avvio sincronizzato, e i percentili vengono ricalcolati a
-partire dagli istogrammi uniti anziché essere mediati — mediare i P95 dei vari
-worker restituisce un numero diverso, non un'approssimazione. Le esecuzioni
-possono anche estendersi su più macchine tramite una barriera di avvio condivisa
-e il nuovo collector `merge-load-test`. Vedi
-[Test di carico](#-test-di-carico).
-
-Inoltre: soglie pass/fail per la CI, output live per intervallo, controllo del
-backlog in modo che il sovraccarico si manifesti come richieste scartate anziché
-come latenza gonfiata, e codici di successo definiti dall'utente tramite
-`--expected-status`.
-
 ## Indice
 
 - [Perché net-benchmark?](#perché-net-benchmark)

--- a/README.md
+++ b/README.md
@@ -64,20 +64,6 @@ net-benchmark http load-test -t https://checkout.example.com/api/cart \
   --threshold 'p95_latency<400'
 ```
 
-### What's new in 0.5.2
-
-**Distributed load testing.** A single Python process is usually the bottleneck
-long before your target is. `--workers N` generates load from N separate
-processes with a synchronised start, and percentiles are recalculated from
-merged histograms rather than averaged — averaging P95s across workers gives a
-different number, not an approximation. Runs can also span several machines via
-a shared start barrier and the new `merge-load-test` collector. See
-[Load Testing](#-load-testing).
-
-Also: pass/fail thresholds for CI, per-interval live output, backlog control so
-overload shows up as drops instead of inflated latency, and user-defined success
-codes via `--expected-status`.
-
 ## Table of Contents
 
 - [Why net-benchmark?](#why-net-benchmark)

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,17 +57,6 @@ net-benchmark http load-test -t https://checkout.example.com/api/cart \
   --threshold 'p95_latency<400'
 ```
 
-### 0.5.2 新增内容
-
-**分布式负载测试。** 在目标被压垮之前，单个 Python 进程往往先成为瓶颈。
-`--workers N` 现在可以从 N 个独立进程发起负载并同步启动；百分位数由**合并后的
-直方图重新计算**，而不是对各 worker 的结果取平均——把多个 P95 平均起来得到的是
-另一个数字，而非近似值。负载还可通过共享启动屏障跨多台机器运行，并用新的
-`merge-load-test` 收集器合并。参见[负载测试](#-负载测试)。
-
-此外：面向 CI 的通过/失败阈值、逐区间实时输出、backlog 控制（使过载表现为丢弃而非
-虚高的延迟），以及通过 `--expected-status` 自定义成功状态码。
-
 ## 目录
 
 - [为什么选择 net-benchmark？](#为什么选择-net-benchmark)


### PR DESCRIPTION
Several releases have shipped since (0.5.3-0.5.6, plus 0.6.0 SSL work in progress) -- a 0.5.2 callout sitting at the top of the README is no longer new and reads as stale. The substantive content (distributed load testing, --workers N, merged-histogram percentiles, --expected-status) already lives in the Load Testing section proper; the callout was only ever a pointer to it, so nothing is lost by removing it.

Same stale block existed in README.md, README.it.md, and README.zh.md (README-pypi.md never had it). Removed from all three.